### PR TITLE
Use Sequelize in question model

### DIFF
--- a/server/api/routes/quizzes.js
+++ b/server/api/routes/quizzes.js
@@ -9,7 +9,11 @@ const router = express.Router();
  */
 router.post("/start/:id", authMiddleware, async (req, res) => {
   const quizId = req.params.id;
-  const userId = req.user.id;
+  const userId = req.user && req.user.id;
+
+  if (userId === undefined) {
+    return res.status(401).json({ error: "Invalid user" });
+  }
 
   const quiz = await quizzesController.startQuiz(quizId, userId);
   res.status(200).json(quiz);

--- a/server/models/attempt.js
+++ b/server/models/attempt.js
@@ -1,99 +1,267 @@
-const database = new (require("../config/database"))();
+const { DataTypes, QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const UserAttempt = sequelize.define('user_attempt', {
+  quiz_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  user_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  attempt_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  start_time: DataTypes.DATE,
+  end_time: DataTypes.DATE,
+  remaining_time: DataTypes.INTEGER,
+  grade: DataTypes.DECIMAL(5, 2)
+}, {
+  tableName: 'user_attempt',
+  timestamps: false
+});
+
+const UserRating = sequelize.define('user_rating', {
+  user_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  quiz_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  rating_given: DataTypes.INTEGER
+}, {
+  tableName: 'user_rating',
+  timestamps: false
+});
+
+const UserAnswerQuestion = sequelize.define('user_answer_question', {
+  user_id: DataTypes.INTEGER,
+  quiz_id: DataTypes.INTEGER,
+  attempt_id: DataTypes.INTEGER,
+  question_id: DataTypes.INTEGER,
+  answer_text: DataTypes.STRING
+}, {
+  tableName: 'user_answer_question',
+  timestamps: false
+});
+
+const Quiz = sequelize.define('quiz', {
+  quiz_id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true
+  },
+  time_allowed: DataTypes.INTEGER
+}, {
+  tableName: 'quiz',
+  timestamps: false
+});
+
+UserAttempt.belongsTo(Quiz, { foreignKey: 'quiz_id' });
 
 class AttemptModel {
   constructor() {
-    this.db = database;
+    this.UserAttempt = UserAttempt;
+    this.UserRating = UserRating;
+    this.UserAnswerQuestion = UserAnswerQuestion;
   }
 
   async findLatest(quizId, userId) {
-    return await this.db.executeQuery(`SELECT attempt_id, start_time, end_time 
-    FROM user_attempt 
-    WHERE user_id = ${userId} AND quiz_id = ${quizId}
-    ORDER BY attempt_id DESC LIMIT 1`);
+    if (quizId === undefined || userId === undefined) {
+      return { error: new Error('Missing quizId or userId'), response: null };
+    }
+    try {
+      const attempt = await this.UserAttempt.findOne({
+        where: { quiz_id: quizId, user_id: userId },
+        order: [['attempt_id', 'DESC']],
+        attributes: ['attempt_id', 'start_time', 'end_time']
+      });
+      return { error: null, response: attempt ? [attempt.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(quizId, userId, attemptId) {
-    return await this.db.executeQuery(`SELECT ua.attempt_id, ua.user_id, ua.quiz_id, ua.start_time, ua.end_time
-    FROM user_attempt ua
-    WHERE ua.quiz_id = ${quizId} AND ua.user_id = ${userId} AND ua.attempt_id = ${attemptId}`)
+    try {
+      const attempt = await this.UserAttempt.findOne({
+        where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId },
+        attributes: ['attempt_id', 'user_id', 'quiz_id', 'start_time', 'end_time']
+      });
+      return { error: null, response: attempt ? [attempt.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAll() {
-    return await this.db.executeQuery(
-      `SELECT quiz_id, AVG(user_rating.rating_given) as average_rating, COUNT(user_rating.rating_given) as rating_count FROM user_rating GROUP BY quiz_id`
-    );
+    try {
+      const res = await this.UserRating.findAll({
+        attributes: [
+          'quiz_id',
+          [sequelize.fn('AVG', sequelize.col('rating_given')), 'average_rating'],
+          [sequelize.fn('COUNT', sequelize.col('rating_given')), 'rating_count']
+        ],
+        group: ['quiz_id']
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addOne({quizId, userId, attemptId, startTime}) {
-    return await this.db.executeQuery(
-      `INSERT INTO user_attempt (quiz_id, user_id, attempt_id, start_time) VALUES ('${quizId}', '${userId}', '${attemptId}', '${startTime}')`
-    );
+    try {
+      const res = await this.UserAttempt.create({
+        quiz_id: quizId,
+        user_id: userId,
+        attempt_id: attemptId,
+        start_time: startTime
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async saveOne({ quizId, userId, ratingGiven }) {
-    return await this.db.executeQuery(`UPDATE user_rating 
-    SET rating_given = '${ratingGiven}'
-    WHERE user_rating.user_id = ${userId} AND user_rating.quiz_id = ${quizId}`);
+    try {
+      const [rows] = await this.UserRating.update({
+        rating_given: ratingGiven
+      }, {
+        where: { user_id: userId, quiz_id: quizId }
+      });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(quizId, userId) {
-    return await this.db.executeQuery(`DELETE FROM user_rating 
-    WHERE user_rating.user_id = ${userId} AND user_rating.quiz_id = ${quizId}`);
-  }
-
-  async addOnePlaceholder({quizId, userId, attemptId, questionId}) {
-    return await this.db.executeQuery(`INSERT INTO user_answer_question (quiz_id, user_id, attempt_id, question_id, answer_text) 
-    VALUES ('${quizId}', '${userId}', '${attemptId}', '${questionId}', '')`)
-  }
-
-  async addManyPlaceholders({quizId, userId, attemptId, questionIds}) {
-    let query = `INSERT INTO user_answer_question (quiz_id, user_id, attempt_id, question_id, answer_text) VALUES `;
-
-    for (let i = 0; i < questionIds.length; i++) {
-      query = query.concat(
-        `('${quizId}', '${userId}', '${attemptId}', '${questionIds[i]}', ''), `
-      );
+    try {
+      const rows = await this.UserRating.destroy({
+        where: { user_id: userId, quiz_id: quizId }
+      });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
     }
+  }
 
-    let formattedQuery = query.substring(0, query.length - 2);
+  async addOnePlaceholder({ quizId, userId, attemptId, questionId }) {
+    try {
+      const res = await this.UserAnswerQuestion.create({
+        quiz_id: quizId,
+        user_id: userId,
+        attempt_id: attemptId,
+        question_id: questionId,
+        answer_text: ''
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
+  }
 
-    console.log(formattedQuery);
-
-    return await this.db.executeQuery(formattedQuery);
+  async addManyPlaceholders({ quizId, userId, attemptId, questionIds }) {
+    const records = questionIds.map(id => ({
+      quiz_id: quizId,
+      user_id: userId,
+      attempt_id: attemptId,
+      question_id: id,
+      answer_text: ''
+    }));
+    try {
+      const res = await this.UserAnswerQuestion.bulkCreate(records);
+      return { error: null, response: { affectedRows: res.length } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async closeOne({quizId, userId, attemptId, endTime, grade}) {
-    return await this.db.executeQuery(`UPDATE user_attempt 
-    SET end_time = '${endTime}', grade = ${grade}, remaining_time = 0
-    WHERE quiz_id = ${quizId} AND user_id = ${userId} AND attempt_id = ${attemptId}`);
+    try {
+      const [rows] = await this.UserAttempt.update({
+        end_time: endTime,
+        grade,
+        remaining_time: 0
+      }, {
+        where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId }
+      });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findIncompleteAttempts(quizId) {
-    return await this.db.executeQuery(`SELECT user_id, quiz_id, attempt_id FROM user_attempt ua
-    WHERE ua.quiz_id = ${quizId} AND ua.end_time IS NULL AND grade IS NULL`)
+    try {
+      const attempts = await this.UserAttempt.findAll({
+        where: { quiz_id: quizId, end_time: null, grade: null },
+        attributes: ['user_id', 'quiz_id', 'attempt_id']
+      });
+      return { error: null, response: attempts.map(a => a.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAllIncompleteAttempts() {
-    return await this.db.executeQuery(`SELECT ua.attempt_id, ua.user_id, ua.quiz_id, ua.start_time, q.time_allowed 
-    FROM user_attempt ua JOIN quiz q ON ua.quiz_id = q.quiz_id
-    WHERE ua.end_time IS NULL 
-    ORDER BY start_time`)
+    try {
+      const attempts = await this.UserAttempt.findAll({
+        where: { end_time: null },
+        include: [{ model: Quiz, attributes: ['time_allowed'] }],
+        order: [['start_time', 'ASC']],
+        attributes: ['attempt_id', 'user_id', 'quiz_id', 'start_time']
+      });
+      const result = attempts.map(a => {
+        const obj = a.toJSON();
+        obj.time_allowed = obj.quiz.time_allowed;
+        delete obj.quiz;
+        return obj;
+      });
+      return { error: null, response: result };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findIncompleteAttempt(quizId, userId, attemptId) {
-    return await this.db.executeQuery(`SELECT ua.attempt_id, ua.user_id, ua.quiz_id, ua.start_time, q.time_allowed 
-    FROM user_attempt ua JOIN quiz q ON ua.quiz_id = q.quiz_id
-    WHERE ua.quiz_id = ${quizId} AND user_id = ${userId} AND attempt_id = ${attemptId} AND ua.end_time IS NULL`)
+    try {
+      const attempt = await this.UserAttempt.findOne({
+        where: { quiz_id: quizId, user_id: userId, attempt_id, end_time: null },
+        include: [{ model: Quiz, attributes: ['time_allowed'] }],
+        attributes: ['attempt_id', 'user_id', 'quiz_id', 'start_time']
+      });
+      if (!attempt) return { error: null, response: [] };
+      const obj = attempt.toJSON();
+      obj.time_allowed = obj.quiz.time_allowed;
+      delete obj.quiz;
+      return { error: null, response: [obj] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findManyIncompleteAttempts(userId) {
-    return await this.db.executeQuery(`SELECT ua.attempt_id, ua.user_id, ua.quiz_id, ua.start_time, q.time_allowed, total_questions, unanswered, (total_questions - unanswered) as answered
-    FROM user_attempt ua JOIN quiz q ON ua.quiz_id = q.quiz_id
-    JOIN (SELECT COUNT(*) as total_questions, SUM(CASE WHEN answer_text LIKE '' THEN 1 ELSE 0 END) as unanswered, SUM(CASE WHEN answer_text NOT LIKE '' THEN 1 ELSE 0 END) as answered, attempt_id, quiz_id, user_id
-    FROM user_answer_question uaq 
-    GROUP BY attempt_id, quiz_id, user_id ) t1 ON t1.attempt_id = ua.attempt_id AND t1.quiz_id = ua.quiz_id AND t1.user_id = ua.user_id
-    WHERE ua.user_id = ${userId} AND ua.end_time IS NULL
-    ORDER BY ua.quiz_id, ua.attempt_id`)
+    try {
+      const results = await sequelize.query(
+        `SELECT ua.attempt_id, ua.user_id, ua.quiz_id, ua.start_time, q.time_allowed, total_questions, unanswered, (total_questions - unanswered) as answered
+        FROM user_attempt ua JOIN quiz q ON ua.quiz_id = q.quiz_id
+        JOIN (SELECT COUNT(*) as total_questions, SUM(CASE WHEN answer_text = '' THEN 1 ELSE 0 END) as unanswered, SUM(CASE WHEN answer_text <> '' THEN 1 ELSE 0 END) as answered, attempt_id, quiz_id, user_id
+        FROM user_answer_question
+        GROUP BY attempt_id, quiz_id, user_id) t1 ON t1.attempt_id = ua.attempt_id AND t1.quiz_id = ua.quiz_id AND t1.user_id = ua.user_id
+        WHERE ua.user_id = :userId AND ua.end_time IS NULL
+        ORDER BY ua.quiz_id, ua.attempt_id`,
+        { replacements: { userId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: results };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/correct_answer.js
+++ b/server/models/correct_answer.js
@@ -1,25 +1,103 @@
-const { QueryTypes } = require('sequelize');
+const { DataTypes } = require('sequelize');
 const sequelize = require('../config/orm');
+
+const Question = sequelize.define('question', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  type_id: DataTypes.INTEGER,
+  instruction_id: DataTypes.INTEGER,
+  is_active: DataTypes.BOOLEAN
+}, { tableName: 'question', timestamps: false });
+
+const QuizQuestion = sequelize.define('quiz_question', {
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true }
+}, { tableName: 'quiz_question', timestamps: false });
+
+const QuestionMultipleChoice = sequelize.define('question_multiple_choice', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_text: DataTypes.STRING,
+  is_correct_choice: DataTypes.BOOLEAN
+}, { tableName: 'question_multiple_choice', timestamps: false });
+
+const QuestionGapFilling = sequelize.define('question_gap_filling', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  sequence_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answer: DataTypes.STRING
+}, { tableName: 'question_gap_filling', timestamps: false });
+
+const QuestionMatching = sequelize.define('question_matching', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answers: DataTypes.STRING
+}, { tableName: 'question_matching', timestamps: false });
+
+Question.hasMany(QuestionMultipleChoice, { foreignKey: 'question_id' });
+Question.hasMany(QuestionGapFilling, { foreignKey: 'question_id' });
+Question.hasOne(QuestionMatching, { foreignKey: 'question_id' });
 
 class CorrectAnswerModel {
   constructor() {}
 
   async findAll(quizId) {
     try {
-      const res = await sequelize.query(
-        `SELECT q.question_id, qmc.choice_text, qmc.choice_id, qmc.is_correct_choice,
-                qgf.sequence_id, qgf.correct_answer, qm.correct_answers, q.type_id
-         FROM question q
-         JOIN quiz_question qq ON qq.question_id = q.question_id
-         JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-         LEFT JOIN question_multiple_choice qmc ON q.question_id = qmc.question_id
-         LEFT JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
-         LEFT JOIN question_matching qm ON q.question_id = qm.question_id
-         WHERE qq.quiz_id = :quizId AND q.is_active = 1
-         ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id`,
-        { replacements: { quizId }, type: QueryTypes.SELECT }
-      );
-      return { error: null, response: res };
+      const questions = await Question.findAll({
+        where: { is_active: 1 },
+        include: [
+          { model: QuizQuestion, where: { quiz_id: quizId }, attributes: [] },
+          { model: QuestionMultipleChoice, attributes: ['choice_text', 'choice_id', 'is_correct_choice'], required: false },
+          { model: QuestionGapFilling, attributes: ['sequence_id', 'correct_answer'], required: false },
+          { model: QuestionMatching, attributes: ['correct_answers'], required: false }
+        ],
+        attributes: ['question_id', 'type_id'],
+        order: [
+          ['question_id', 'ASC'],
+          [QuestionMultipleChoice, 'choice_id', 'ASC'],
+          [QuestionGapFilling, 'sequence_id', 'ASC']
+        ]
+      });
+
+      const output = [];
+      for (const q of questions) {
+        const data = q.toJSON();
+        const correctAnswers = data.question_matching ? data.question_matching.correct_answers : null;
+        if (data.question_multiple_choices.length > 0) {
+          data.question_multiple_choices.forEach(c => output.push({
+            question_id: data.question_id,
+            choice_text: c.choice_text,
+            choice_id: c.choice_id,
+            is_correct_choice: c.is_correct_choice,
+            sequence_id: null,
+            correct_answer: null,
+            correct_answers: correctAnswers,
+            type_id: data.type_id
+          }));
+        }
+        if (data.question_gap_fillings.length > 0) {
+          data.question_gap_fillings.forEach(g => output.push({
+            question_id: data.question_id,
+            choice_text: null,
+            choice_id: null,
+            is_correct_choice: null,
+            sequence_id: g.sequence_id,
+            correct_answer: g.correct_answer,
+            correct_answers: correctAnswers,
+            type_id: data.type_id
+          }));
+        }
+        if (data.question_multiple_choices.length === 0 && data.question_gap_fillings.length === 0) {
+          output.push({
+            question_id: data.question_id,
+            choice_text: null,
+            choice_id: null,
+            is_correct_choice: null,
+            sequence_id: null,
+            correct_answer: null,
+            correct_answers: correctAnswers,
+            type_id: data.type_id
+          });
+        }
+      }
+      return { error: null, response: output };
     } catch (error) {
       return { error };
     }

--- a/server/models/correct_answer.js
+++ b/server/models/correct_answer.js
@@ -1,20 +1,28 @@
-const database = new (require("../config/database"))();
+const { QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
 
 class CorrectAnswerModel {
-  constructor() {
-    this.db = database;
-  }
+  constructor() {}
 
   async findAll(quizId) {
-    return await this.db.executeQuery(`SELECT q.question_id, qmc.choice_text, qmc.choice_id, qmc.is_correct_choice, qgf.sequence_id, qgf.correct_answer, qm.correct_answers, q.type_id
-    FROM question q 
-    JOIN quiz_question qq ON qq.question_id = q.question_id 
-    JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-    LEFT JOIN question_multiple_choice qmc ON q.question_id =  qmc.question_id
-    LEFT JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
-    LEFT JOIN question_matching qm ON q.question_id = qm.question_id
-    WHERE qq.quiz_id = ${quizId} AND q.is_active = 1
-    ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id`);
+    try {
+      const res = await sequelize.query(
+        `SELECT q.question_id, qmc.choice_text, qmc.choice_id, qmc.is_correct_choice,
+                qgf.sequence_id, qgf.correct_answer, qm.correct_answers, q.type_id
+         FROM question q
+         JOIN quiz_question qq ON qq.question_id = q.question_id
+         JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
+         LEFT JOIN question_multiple_choice qmc ON q.question_id = qmc.question_id
+         LEFT JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
+         LEFT JOIN question_matching qm ON q.question_id = qm.question_id
+         WHERE qq.quiz_id = :quizId AND q.is_active = 1
+         ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id`,
+        { replacements: { quizId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/favorite.js
+++ b/server/models/favorite.js
@@ -1,23 +1,41 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const UserFavorite = sequelize.define('user_favorite', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true }
+}, { tableName: 'user_favorite', timestamps: false });
 
 class FavoriteModel {
   constructor() {
-    this.db = database;
+    this.UserFavorite = UserFavorite;
   }
 
   async findOne(quizId, userId) {
-    return await this.db.executeQuery(`SELECT COUNT(*) as favorite FROM user_favorite 
-    WHERE user_favorite.user_id = ${userId} AND user_favorite.quiz_id = ${quizId}`)  
+    try {
+      const count = await this.UserFavorite.count({ where: { quiz_id: quizId, user_id: userId } });
+      return { error: null, response: [{ favorite: count }] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addOne(quizId, userId) {
-    return await this.db.executeQuery(`
-    INSERT INTO user_favorite (user_id, quiz_id) VALUES ('${userId}', '${quizId}')`)
+    try {
+      const res = await this.UserFavorite.create({ user_id: userId, quiz_id: quizId });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(quizId, userId) {
-    return await this.db.executeQuery(`DELETE FROM user_favorite 
-    WHERE user_favorite.user_id = ${userId} AND user_favorite.quiz_id = ${quizId}`)
+    try {
+      const rows = await this.UserFavorite.destroy({ where: { user_id: userId, quiz_id: quizId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/gap_filling_option.js
+++ b/server/models/gap_filling_option.js
@@ -1,39 +1,58 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuestionGapFilling = sequelize.define('question_gap_filling', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  sequence_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answer: DataTypes.STRING
+}, { tableName: 'question_gap_filling', timestamps: false });
 
 class GapFillingOptionModel {
   constructor() {
-    this.db = database;
+    this.QuestionGapFilling = QuestionGapFilling;
   }
 
   async findMany(questionId) {
-    return await this.db.executeQuery(`SELECT qgf.sequence_id, qgf.correct_answer
-    FROM question q 
-    JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
-    WHERE q.question_id = ${questionId}
-    ORDER BY sequence_id`)
+    try {
+      const res = await this.QuestionGapFilling.findAll({
+        where: { question_id: questionId },
+        attributes: ['sequence_id', 'correct_answer'],
+        order: [['sequence_id', 'ASC']]
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addMany(items, questionId) {
-    let query = `INSERT INTO question_gap_filling (question_id, sequence_id, correct_answer) VALUES `;
-
-    for (let i = 0; i < items.length; i++) {
-      query = query.concat(
-        `(${questionId}, ${items[i].sequence_id}, '${items[i].correct_answer}'), `
-      );
+    const records = items.map(i => ({
+      question_id: questionId,
+      sequence_id: i.sequence_id,
+      correct_answer: i.correct_answer
+    }));
+    try {
+      const res = await this.QuestionGapFilling.bulkCreate(records);
+      return { error: null, response: { affectedRows: res.length } };
+    } catch (error) {
+      return { error };
     }
-
-    let formattedQuery = query.substring(0, query.length - 2);
-
-    return await this.db.executeQuery(formattedQuery)
   }
 
   async saveMany(items, questionId) {
-    let query = ''
-    for (const { sequence_id, correct_answer} of items) {
-      query += `UPDATE question_gap_filling SET correct_answer = '${correct_answer}' WHERE sequence_id = ${sequence_id} AND question_id = ${questionId};`;
+    try {
+      const promises = items.map(({ sequence_id, correct_answer }) =>
+        this.QuestionGapFilling.update(
+          { correct_answer },
+          { where: { sequence_id, question_id: questionId } }
+        )
+      );
+      const results = await Promise.all(promises);
+      const affectedRows = results.reduce((a, [c]) => a + c, 0);
+      return { error: null, response: { affectedRows } };
+    } catch (error) {
+      return { error };
     }
-    
-    return await this.db.executeQuery(query)
   }
 }
 

--- a/server/models/home.js
+++ b/server/models/home.js
@@ -1,23 +1,51 @@
-const { QueryTypes } = require('sequelize');
+const { DataTypes, literal } = require('sequelize');
 const sequelize = require('../config/orm');
 
+const Quiz = sequelize.define('quiz', {
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  course_name: DataTypes.STRING,
+  skill_id: DataTypes.INTEGER,
+  description: DataTypes.TEXT,
+  is_active: DataTypes.BOOLEAN,
+  time_allowed: DataTypes.INTEGER,
+  created_by: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'quiz', timestamps: false });
+
+const QuizSkill = sequelize.define('quiz_skill', {
+  skill_id: { type: DataTypes.INTEGER, primaryKey: true },
+  skill_description: DataTypes.STRING
+}, { tableName: 'quiz_skill', timestamps: false });
+
+Quiz.belongsTo(QuizSkill, { foreignKey: 'skill_id' });
+
 class FavoriteModel {
-  constructor() {}
+  constructor() {
+    this.Quiz = Quiz;
+  }
 
   async getHomeSummary(userId) {
     try {
-      const res = await sequelize.query(
-        `SELECT quiz.*, quiz_skill.skill_description,
-        (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-        (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions,
-        COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
-        COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count,
-        COALESCE((SELECT user_rating.rating_given FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id AND user_rating.user_id = :userId), 0) as rating_given,
-        COALESCE((SELECT COUNT(*) FROM user_favorite WHERE user_favorite.quiz_id = quiz.quiz_id AND user_favorite.user_id = :userId), 0) as favorite
-        FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
-        WHERE quiz.is_active = 1`,
-        { replacements: { userId }, type: QueryTypes.SELECT }
-      );
+      const quizzes = await this.Quiz.findAll({
+        where: { is_active: 1 },
+        include: [{ model: QuizSkill, attributes: ['skill_description'] }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id)'), 'attempts'],
+            [literal('(SELECT COUNT(*) FROM quiz_question WHERE quiz_question.quiz_id = quiz.quiz_id)'), 'number_of_questions'],
+            [literal('COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0)'), 'average_rating'],
+            [literal('COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0)'), 'rating_count'],
+            [literal(`COALESCE((SELECT user_rating.rating_given FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id AND user_rating.user_id = ${sequelize.escape(userId)}), 0)`), 'rating_given'],
+            [literal(`COALESCE((SELECT COUNT(*) FROM user_favorite WHERE user_favorite.quiz_id = quiz.quiz_id AND user_favorite.user_id = ${sequelize.escape(userId)}), 0)`), 'favorite']
+          ]
+        }
+      });
+      const res = quizzes.map(q => {
+        const obj = q.toJSON();
+        obj.skill_description = obj.quiz_skill.skill_description;
+        delete obj.quiz_skill;
+        return obj;
+      });
       return { error: null, response: res };
     } catch (error) {
       return { error };
@@ -26,16 +54,24 @@ class FavoriteModel {
 
   async getHomeSummaryForGuest() {
     try {
-      const res = await sequelize.query(
-        `SELECT quiz.*, quiz_skill.skill_description,
-        (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-        (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions,
-        COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
-        COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count
-        FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
-        WHERE quiz.is_active = 1`,
-        { type: QueryTypes.SELECT }
-      );
+      const quizzes = await this.Quiz.findAll({
+        where: { is_active: 1 },
+        include: [{ model: QuizSkill, attributes: ['skill_description'] }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id)'), 'attempts'],
+            [literal('(SELECT COUNT(*) FROM quiz_question WHERE quiz_question.quiz_id = quiz.quiz_id)'), 'number_of_questions'],
+            [literal('COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0)'), 'average_rating'],
+            [literal('COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0)'), 'rating_count']
+          ]
+        }
+      });
+      const res = quizzes.map(q => {
+        const obj = q.toJSON();
+        obj.skill_description = obj.quiz_skill.skill_description;
+        delete obj.quiz_skill;
+        return obj;
+      });
       return { error: null, response: res };
     } catch (error) {
       return { error };

--- a/server/models/home.js
+++ b/server/models/home.js
@@ -1,32 +1,45 @@
-const database = new (require("../config/database"))();
+const { QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
 
 class FavoriteModel {
-  constructor() {
-    this.db = database;
-  }
+  constructor() {}
 
   async getHomeSummary(userId) {
-    return await this.db
-      .executeQuery(`SELECT quiz.*, quiz_skill.skill_description, 
-    (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS 'number_of_questions',
-    COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
-    COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count,
-    COALESCE((SELECT user_rating.rating_given FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id AND user_rating.user_id = ${userId}), 0) as rating_given,
-    COALESCE((SELECT COUNT(*) FROM user_favorite WHERE user_favorite.quiz_id = quiz.quiz_id AND user_favorite.user_id = ${userId}), 0) as favorite
-    FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
-    WHERE quiz.is_active = 1`);
+    try {
+      const res = await sequelize.query(
+        `SELECT quiz.*, quiz_skill.skill_description,
+        (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
+        (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions,
+        COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
+        COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count,
+        COALESCE((SELECT user_rating.rating_given FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id AND user_rating.user_id = :userId), 0) as rating_given,
+        COALESCE((SELECT COUNT(*) FROM user_favorite WHERE user_favorite.quiz_id = quiz.quiz_id AND user_favorite.user_id = :userId), 0) as favorite
+        FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
+        WHERE quiz.is_active = 1`,
+        { replacements: { userId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async getHomeSummaryForGuest() {
-    return await this.db
-      .executeQuery(`SELECT quiz.*, quiz_skill.skill_description, 
-    (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS 'number_of_questions',
-    COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
-    COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count
-    FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
-    WHERE quiz.is_active = 1`);
+    try {
+      const res = await sequelize.query(
+        `SELECT quiz.*, quiz_skill.skill_description,
+        (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
+        (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions,
+        COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
+        COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count
+        FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
+        WHERE quiz.is_active = 1`,
+        { type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/instruction.js
+++ b/server/models/instruction.js
@@ -1,16 +1,38 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuestionInstruction = sequelize.define('question_instruction', {
+  instruction_id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+  instruction: DataTypes.STRING
+}, { tableName: 'question_instruction', timestamps: false });
 
 class InstructionModel {
   constructor() {
-    this.db = database;
+    this.QuestionInstruction = QuestionInstruction;
   }
 
   async addOne(instruction) {
-    return await this.db.executeQuery(`INSERT IGNORE INTO question_instruction(instruction) VALUES ('${instruction}')`)
+    try {
+      const [res] = await this.QuestionInstruction.findOrCreate({
+        where: { instruction },
+        defaults: { instruction }
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0, instruction_id: res.instruction_id } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(instruction) {
-    return await this.db.executeQuery(`SELECT instruction_id FROM question_instruction WHERE instruction = '${instruction}'`)
+    try {
+      const res = await this.QuestionInstruction.findOne({
+        where: { instruction },
+        attributes: ['instruction_id']
+      });
+      return { error: null, response: res ? [res.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/matching_option.js
+++ b/server/models/matching_option.js
@@ -1,63 +1,103 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuestionMatching = sequelize.define('question_matching', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answers: DataTypes.STRING,
+  shuffle_answers: DataTypes.BOOLEAN
+}, { tableName: 'question_matching', timestamps: false });
+
+const QuestionMatchingSub = sequelize.define('question_matching_sub', {
+  subquestion_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  text: DataTypes.STRING,
+  letter: DataTypes.STRING,
+  column_assigned: DataTypes.INTEGER
+}, { tableName: 'question_matching_sub', timestamps: false });
 
 class AnswerModel {
   constructor() {
-    this.db = database;
+    this.QuestionMatching = QuestionMatching;
+    this.QuestionMatchingSub = QuestionMatchingSub;
   }
 
   async findMany(questionId) {
-    return await this.db.executeQuery(`SELECT qms.subquestion_id, qms.letter, qms.text, qms.column_assigned
-    FROM question q
-    JOIN question_matching_sub qms ON q.question_id = qms.question_id
-    WHERE q.question_id = ${questionId}`)
+    try {
+      const res = await this.QuestionMatchingSub.findAll({
+        where: { question_id: questionId },
+        attributes: ['subquestion_id', 'letter', 'text', 'column_assigned'],
+        order: [['subquestion_id', 'ASC']]
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addQuestion(questionId, correctAnswers, shuffleAnswers) {
-    return await this.db.executeQuery(`INSERT INTO question_matching (question_id, correct_answers, shuffle_answers) 
-    VALUES ('${correctAnswers}', '${questionId}', '${shuffleAnswers}')`)
+    try {
+      const res = await this.QuestionMatching.create({
+        question_id: questionId,
+        correct_answers: correctAnswers,
+        shuffle_answers: shuffleAnswers
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addMany(leftItems, rightItems, questionId) {
-    let query = `INSERT INTO question_matching_sub (subquestion_id, question_id, text, letter, column_assigned) VALUES `;
-
+    const records = [];
     for (let i = 0; i < leftItems.length; i++) {
-      query = query.concat(
-        `('${i + 1}', ${questionId}, '${leftItems[i].item}', '${
-          leftItems[i].letter
-        }', '1'), `
-      );
+      records.push({
+        subquestion_id: i + 1,
+        question_id: questionId,
+        text: leftItems[i].item,
+        letter: leftItems[i].letter,
+        column_assigned: 1
+      });
     }
-
     for (let i = 0; i < rightItems.length; i++) {
-      query = query.concat(
-        `('${i + 1}', ${questionId}, '${rightItems[i].item}', '${
-          rightItems[i].letter
-        }', '2'), `
-      );
+      records.push({
+        subquestion_id: i + 1,
+        question_id: questionId,
+        text: rightItems[i].item,
+        letter: rightItems[i].letter,
+        column_assigned: 2
+      });
     }
-
-    let formattedQuery = query.substring(0, query.length - 2);
-
-    console.log(formattedQuery);
-
-    return await this.db.executeQuery(formattedQuery)
+    try {
+      const res = await this.QuestionMatchingSub.bulkCreate(records);
+      return { error: null, response: { affectedRows: res.length } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async saveMany(items, questionId) {
-    let query = ''
-    for (const { subquestion_id, text, item, letter, column_assigned} of items) {
-      query += `UPDATE question_matching_sub 
-      SET letter = '${letter}', text = '${item ? item : text}'
-      WHERE subquestion_id = ${subquestion_id} AND question_id = ${questionId} AND column_assigned = ${column_assigned};`;
+    try {
+      const promises = items.map(({ subquestion_id, text, item, letter, column_assigned }) =>
+        this.QuestionMatchingSub.update(
+          { letter, text: item ? item : text },
+          { where: { subquestion_id, question_id: questionId, column_assigned } }
+        )
+      );
+      const results = await Promise.all(promises);
+      const affectedRows = results.reduce((a, [c]) => a + c, 0);
+      return { error: null, response: { affectedRows } };
+    } catch (error) {
+      return { error };
     }
-    
-    return await this.db.executeQuery(query)
   }
 
   async saveMatchingQuestion(correctAnswers, questionId) {
-    return await this.db.executeQuery(`UPDATE question_matching 
-    SET correct_answers = '${correctAnswers}'
-    WHERE question_id = ${questionId}`)
+    try {
+      const [rows] = await this.QuestionMatching.update({ correct_answers: correctAnswers }, { where: { question_id: questionId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/mime_type.js
+++ b/server/models/mime_type.js
@@ -1,18 +1,33 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const MimeType = sequelize.define('mime_type', {
+  mime_id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+  image_url: DataTypes.STRING,
+  image_alt: DataTypes.STRING
+}, { tableName: 'mime_type', timestamps: false });
 
 class MimeTypeModel {
   constructor() {
-    this.db = database;
+    this.MimeType = MimeType;
   }
 
   async addOne({ image_url, image_alt }) {
-    return await this.db.executeQuery(`
-    INSERT INTO mime_type (image_url, image_alt)
-    VALUES ('${image_url}', '${image_alt}')`)
+    try {
+      const res = await this.MimeType.create({ image_url, image_alt });
+      return { error: null, response: { affectedRows: res ? 1 : 0, mime_id: res.mime_id } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(mimeId) {
-    return await this.db.executeQuery(`SELECT image_url, image_alt FROM mime_type WHERE mime_id = '${mimeId}'`)
+    try {
+      const res = await this.MimeType.findByPk(mimeId, { attributes: ['image_url', 'image_alt'] });
+      return { error: null, response: res ? [res.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/multiple_choice_option.js
+++ b/server/models/multiple_choice_option.js
@@ -1,39 +1,60 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuestionMultipleChoice = sequelize.define('question_multiple_choice', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_text: DataTypes.STRING,
+  is_correct_choice: DataTypes.BOOLEAN
+}, { tableName: 'question_multiple_choice', timestamps: false });
 
 class MultipleChoiceOptionModel {
   constructor() {
-    this.db = database;
+    this.QuestionMultipleChoice = QuestionMultipleChoice;
   }
 
   async findMany(questionId) {
-    return await this.db.executeQuery(`SELECT qmc.choice_id, qmc.choice_text, qmc.is_correct_choice
-    FROM question q 
-    JOIN question_multiple_choice qmc ON q.question_id = qmc.question_id
-    WHERE q.question_id = ${questionId}
-    ORDER BY choice_id`)
+    try {
+      const res = await this.QuestionMultipleChoice.findAll({
+        where: { question_id: questionId },
+        attributes: ['choice_id', 'choice_text', 'is_correct_choice'],
+        order: [['choice_id', 'ASC']]
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addMany(items, questionId) {
-    let query = `INSERT INTO question_multiple_choice (question_id, choice_id, choice_text, is_correct_choice) VALUES `;
-
-    for (let i = 0; i < items.length; i++) {
-      query = query.concat(
-        `(${questionId}, ${items[i].choice_id}, '${items[i].choice_text}', '${items[i].is_correct_choice}'), `
-      );
+    const records = items.map(i => ({
+      question_id: questionId,
+      choice_id: i.choice_id,
+      choice_text: i.choice_text,
+      is_correct_choice: i.is_correct_choice
+    }));
+    try {
+      const res = await this.QuestionMultipleChoice.bulkCreate(records);
+      return { error: null, response: { affectedRows: res.length } };
+    } catch (error) {
+      return { error };
     }
-
-    let formattedQuery = query.substring(0, query.length - 2);
-
-    return await this.db.executeQuery(formattedQuery)
   }
 
   async saveMany(items, questionId) {
-    let query = ''
-    for (const { choice_id, choice_text, is_correct_choice} of items) {
-      query += `UPDATE question_multiple_choice SET choice_text = '${choice_text}', is_correct_choice = ${is_correct_choice} WHERE choice_id = ${choice_id} AND question_id = ${questionId};`;
+    try {
+      const promises = items.map(({ choice_id, choice_text, is_correct_choice }) =>
+        this.QuestionMultipleChoice.update(
+          { choice_text, is_correct_choice },
+          { where: { choice_id, question_id: questionId } }
+        )
+      );
+      const results = await Promise.all(promises);
+      const affectedRows = results.reduce((a, [c]) => a + c, 0);
+      return { error: null, response: { affectedRows } };
+    } catch (error) {
+      return { error };
     }
-    
-    return await this.db.executeQuery(query)
   }
 }
 

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -1,46 +1,107 @@
-const database = new (require("../config/database"))();
+const { DataTypes, literal } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const DiscussionPost = sequelize.define('discussion_post', {
+  post_id: { type: DataTypes.INTEGER, primaryKey: true },
+  content: DataTypes.TEXT,
+  thread_id: DataTypes.INTEGER,
+  user_id: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'discussion_post', timestamps: false });
+
+const User = sequelize.define('user', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  first_name: DataTypes.STRING,
+  last_name: DataTypes.STRING,
+  profile_picture_id: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'user', timestamps: false });
+
+const MimeType = sequelize.define('mime_type', {
+  mime_id: { type: DataTypes.INTEGER, primaryKey: true },
+  image_url: DataTypes.STRING
+}, { tableName: 'mime_type', timestamps: false });
+
+DiscussionPost.belongsTo(User, { foreignKey: 'user_id' });
+User.belongsTo(MimeType, { foreignKey: 'profile_picture_id' });
 
 class PostModel {
   constructor() {
-    this.db = database;
+    this.DiscussionPost = DiscussionPost;
   }
 
   async findAll() {
-    return await this.db.executeQuery("SELECT * FROM discussion_post");
+    try {
+      const res = await this.DiscussionPost.findAll();
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
-  
+
   async findDetailed(id) {
-    return await this.db.executeQuery(
-      `SELECT post_id, (SELECT CONCAT(u.first_name, ' ', u.last_name)) as full_name, dp.created_at as posted_at, u.created_at as member_since, dp.content, 
-      (SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = u.user_id) as thread_count,
-      (SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = u.user_id) as post_count,
-      u.profile_picture_id, m.image_url as avatarUrl
-      FROM discussion_post dp JOIN user u ON dp.user_id = u.user_id
-      JOIN mime_type m ON m.mime_id = u.profile_picture_id
-      WHERE dp.post_id = ${id}`
-    );
+    try {
+      const post = await this.DiscussionPost.findOne({
+        where: { post_id: id },
+        include: [{
+          model: User,
+          attributes: [
+            [sequelize.fn('CONCAT', sequelize.col('user.first_name'), ' ', sequelize.col('user.last_name')), 'full_name'],
+            ['created_at', 'member_since'],
+            'profile_picture_id',
+            [literal('(SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = user.user_id)'), 'thread_count'],
+            [literal('(SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = user.user_id)'), 'post_count']
+          ],
+          include: [{ model: MimeType, attributes: [['image_url', 'avatarUrl']] }]
+        }],
+        attributes: ['post_id', 'content', ['created_at', 'posted_at']]
+      });
+      return { error: null, response: post ? [post.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findMany(threadId) {
-    return await this.db
-      .executeQuery(`SELECT post_id, (SELECT CONCAT(u.first_name, ' ', u.last_name)) as full_name, dp.created_at as posted_at, u.created_at as member_since, dp.content, 
-    (SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = u.user_id) as thread_count,
-    (SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = u.user_id) as post_count,
-    u.profile_picture_id, m.image_url as avatarUrl
-    FROM discussion_post dp JOIN user u ON dp.user_id = u.user_id
-    JOIN mime_type m ON m.mime_id = u.profile_picture_id
-    WHERE dp.thread_id = ${threadId}`);
+    try {
+      const posts = await this.DiscussionPost.findAll({
+        where: { thread_id: threadId },
+        include: [{
+          model: User,
+          attributes: [
+            [sequelize.fn('CONCAT', sequelize.col('user.first_name'), ' ', sequelize.col('user.last_name')), 'full_name'],
+            ['created_at', 'member_since'],
+            'profile_picture_id',
+            [literal('(SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = user.user_id)'), 'thread_count'],
+            [literal('(SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = user.user_id)'), 'post_count']
+          ],
+          include: [{ model: MimeType, attributes: [['image_url', 'avatarUrl']] }]
+        }],
+        attributes: ['post_id', 'content', ['created_at', 'posted_at']],
+        order: [['created_at', 'ASC']]
+      });
+      return { error: null, response: posts.map(p => p.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addOne(threadId, content, userId) {
-    return await this.db.executeQuery(`
-    INSERT INTO discussion_post(thread_id, content, user_id) 
-    VALUES ('${threadId}', '${content}', '${userId}');
-    `);
+    try {
+      const res = await this.DiscussionPost.create({ thread_id: threadId, content, user_id: userId });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(id) {
-    return await this.db.executeQuery(`DELETE FROM discussion_post WHERE post_id = ${id}`);
+    try {
+      const rows = await this.DiscussionPost.destroy({ where: { post_id: id } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/question.js
+++ b/server/models/question.js
@@ -1,110 +1,249 @@
-const database = new (require("../config/database"))();
+const { DataTypes, QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const Question = sequelize.define('question', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  type_id: DataTypes.INTEGER,
+  instruction_id: DataTypes.INTEGER,
+  is_active: DataTypes.BOOLEAN,
+  paragraph_title: DataTypes.STRING,
+  question: DataTypes.TEXT
+}, {
+  tableName: 'question',
+  timestamps: false
+});
+
+const QuestionMatching = sequelize.define('question_matching', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answers: DataTypes.STRING,
+  shuffle_answers: DataTypes.BOOLEAN
+}, { tableName: 'question_matching', timestamps: false });
+
+const QuestionType = sequelize.define('question_type', {
+  type_id: { type: DataTypes.INTEGER, primaryKey: true },
+  type_name: DataTypes.STRING
+}, { tableName: 'question_type', timestamps: false });
+
+const QuestionInstruction = sequelize.define('question_instruction', {
+  instruction_id: { type: DataTypes.INTEGER, primaryKey: true },
+  instruction: DataTypes.STRING
+}, { tableName: 'question_instruction', timestamps: false });
+
+const QuizQuestion = sequelize.define('quiz_question', {
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true }
+}, { tableName: 'quiz_question', timestamps: false });
+
+const QuestionMultipleChoice = sequelize.define('question_multiple_choice', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_id: { type: DataTypes.INTEGER, primaryKey: true },
+  choice_text: DataTypes.STRING,
+  is_correct_choice: DataTypes.BOOLEAN
+}, { tableName: 'question_multiple_choice', timestamps: false });
+
+const QuestionGapFilling = sequelize.define('question_gap_filling', {
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  sequence_id: { type: DataTypes.INTEGER, primaryKey: true },
+  correct_answer: DataTypes.STRING
+}, { tableName: 'question_gap_filling', timestamps: false });
+
+const QuestionMatchingSub = sequelize.define('question_matching_sub', {
+  subquestion_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  text: DataTypes.STRING,
+  letter: DataTypes.STRING,
+  column_assigned: DataTypes.INTEGER
+}, { tableName: 'question_matching_sub', timestamps: false });
+
+const UserAnswerQuestion = sequelize.define('user_answer_question', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  attempt_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  answer_text: DataTypes.STRING,
+  is_correct: DataTypes.INTEGER
+}, { tableName: 'user_answer_question', timestamps: false });
+
+Question.belongsTo(QuestionType, { foreignKey: 'type_id' });
+Question.belongsTo(QuestionInstruction, { foreignKey: 'instruction_id' });
+Question.hasOne(QuestionMatching, { foreignKey: 'question_id' });
 
 class QuestionModel {
   constructor() {
-    this.db = database;
+    this.Question = Question;
   }
 
   async findOne(id) {
-    return await this.db.executeQuery(`SELECT * FROM question WHERE question_id = ${id}`);
+    try {
+      const q = await this.Question.findByPk(id);
+      return { error: null, response: q ? [q.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findManyByQuestionId() {}
 
   async findOneForEdit(questionId) {
-    return await this.db
-      .executeQuery(`SELECT q.*, COALESCE(qm.correct_answers, '') as matching_question_correct_answers, qt.type_name, qi.instruction
-    FROM question q 
-    LEFT JOIN question_matching qm ON q.question_id = qm.question_id
-    JOIN question_type qt ON q.type_id = qt.type_id
-    JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-    WHERE q.question_id = ${questionId}`);
+    try {
+      const q = await this.Question.findOne({
+        where: { question_id: questionId },
+        include: [
+          { model: QuestionMatching, attributes: ['correct_answers'], required: false },
+          { model: QuestionType, attributes: ['type_name'] },
+          { model: QuestionInstruction, attributes: ['instruction'] }
+        ]
+      });
+      if (!q) return { error: null, response: [] };
+      const obj = q.toJSON();
+      obj.matching_question_correct_answers = obj.question_matching ? obj.question_matching.correct_answers : '';
+      obj.type_name = obj.question_type.type_name;
+      obj.instruction = obj.question_instruction.instruction;
+      delete obj.question_matching;
+      delete obj.question_type;
+      delete obj.question_instruction;
+      return { error: null, response: [obj] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async loadContent(quizId) {
-    return await this.db
-      .executeQuery(`SELECT q.question_id, qmc.choice_id, qmc.choice_text, qgf.sequence_id , qms.letter, qms.subquestion_id, qms.text, qmc.is_correct_choice, qms.column_assigned
-      FROM question q 
-      JOIN quiz_question qq ON qq.question_id = q.question_id 
+    try {
+      const res = await sequelize.query(
+        `SELECT q.question_id, qmc.choice_id, qmc.choice_text, qgf.sequence_id , qms.letter, qms.subquestion_id, qms.text, qmc.is_correct_choice, qms.column_assigned
+      FROM question q
+      JOIN quiz_question qq ON qq.question_id = q.question_id
       JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
       LEFT JOIN question_multiple_choice qmc ON q.question_id =  qmc.question_id
       LEFT JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
       LEFT JOIN question_matching_sub qms ON q.question_id = qms.question_id
-      WHERE qq.quiz_id = ${quizId} AND q.is_active = 1
-      ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id, qms.subquestion_id`);
+      WHERE qq.quiz_id = :quizId AND q.is_active = 1
+      ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id, qms.subquestion_id`,
+        { replacements: { quizId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findManyByQuizIdForEdit(quizId) {
-    return await this.db
-    .executeQuery(`SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
-        FROM question q 
-        JOIN quiz_question qq ON qq.question_id = q.question_id 
+    try {
+      const res = await sequelize.query(
+        `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
+        FROM question q
+        JOIN quiz_question qq ON qq.question_id = q.question_id
         JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-        JOIN question_type qt ON q.type_id = qt.type_id 
-        WHERE qq.quiz_id = ${quizId}
-        ORDER BY q.question_id`);
+        JOIN question_type qt ON q.type_id = qt.type_id
+        WHERE qq.quiz_id = :quizId
+        ORDER BY q.question_id`,
+        { replacements: { quizId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findManyByQuizId({quizId, userId, attemptId}) {
-    if (attemptId && userId) {
-      return await this.db
-        .executeQuery(`SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction, uaq.*
-            FROM question q 
-            JOIN quiz_question qq ON qq.question_id = q.question_id 
+    try {
+      if (attemptId && userId) {
+        const res = await sequelize.query(
+          `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction, uaq.*
+            FROM question q
+            JOIN quiz_question qq ON qq.question_id = q.question_id
             JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-            JOIN question_type qt ON q.type_id = qt.type_id 
+            JOIN question_type qt ON q.type_id = qt.type_id
             JOIN user_answer_question uaq ON uaq.question_id = q.question_id
-            WHERE uaq.quiz_id = '${quizId}' AND q.is_active = 1 AND uaq.user_id = '${userId}' AND uaq.attempt_id = '${attemptId}'
-            ORDER BY q.question_id`);
-    } else {
-      return await this.db
-        .executeQuery(`SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
-            FROM question q 
-            JOIN quiz_question qq ON qq.question_id = q.question_id 
+            WHERE uaq.quiz_id = :quizId AND q.is_active = 1 AND uaq.user_id = :userId AND uaq.attempt_id = :attemptId
+            ORDER BY q.question_id`,
+          { replacements: { quizId, userId, attemptId }, type: QueryTypes.SELECT }
+        );
+        return { error: null, response: res };
+      } else {
+        const res = await sequelize.query(
+          `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
+            FROM question q
+            JOIN quiz_question qq ON qq.question_id = q.question_id
             JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-            JOIN question_type qt ON q.type_id = qt.type_id 
-            WHERE qq.quiz_id = ${quizId} AND q.is_active = 1
-            ORDER BY q.question_id`);
+            JOIN question_type qt ON q.type_id = qt.type_id
+            WHERE qq.quiz_id = :quizId AND q.is_active = 1
+            ORDER BY q.question_id`,
+          { replacements: { quizId }, type: QueryTypes.SELECT }
+        );
+        return { error: null, response: res };
+      }
+    } catch (error) {
+      return { error };
     }
   }
 
   async findNumberOfQuestions() {
-    return await this.db.executeQuery(`SELECT quiz.quiz_id,
-    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS 'number_of_questions'
-    FROM quiz`);
+    try {
+      const res = await sequelize.query(
+        `SELECT quiz.quiz_id,
+    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions
+    FROM quiz`,
+        { type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addOne({ typeId, instructionId, isActive, paragraphTitle, question }) {
-    return await this.db
-      .executeQuery(`INSERT INTO question(type_id, instruction_id, is_active, paragraph_title, question) 
-    VALUES ('${typeId}', '${instructionId}', '${isActive}', ${
-      !paragraphTitle ? "NULL" : paragraphTitle
-    }, '${question}')`);
+    try {
+      const res = await this.Question.create({
+        type_id: typeId,
+        instruction_id: instructionId,
+        is_active: isActive,
+        paragraph_title: paragraphTitle || null,
+        question
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
   
   async deleteOne(questionId) {
-    return await this.db.executeQuery(`SET FOREIGN_KEY_CHECKS=0;
-    DELETE FROM user_answer_question WHERE question_id = ${questionId};
-    DELETE FROM quiz_question WHERE question_id = ${questionId};
-    DELETE FROM question_multiple_choice WHERE question_id = ${questionId};
-    DELETE FROM question_gap_filling WHERE question_id = ${questionId};
-    DELETE FROM question_matching_sub WHERE question_id = ${questionId};
-    DELETE FROM question_matching WHERE question_id = ${questionId};
-    DELETE FROM question WHERE question_id = ${questionId};
-    SET FOREIGN_KEY_CHECKS=1;
-    `);
+    try {
+      await sequelize.query('SET FOREIGN_KEY_CHECKS=0');
+      await UserAnswerQuestion.destroy({ where: { question_id: questionId } });
+      await QuizQuestion.destroy({ where: { question_id: questionId } });
+      await QuestionMultipleChoice.destroy({ where: { question_id: questionId } });
+      await QuestionGapFilling.destroy({ where: { question_id: questionId } });
+      await QuestionMatchingSub.destroy({ where: { question_id: questionId } });
+      await QuestionMatching.destroy({ where: { question_id: questionId } });
+      const rows = await this.Question.destroy({ where: { question_id: questionId } });
+      await sequelize.query('SET FOREIGN_KEY_CHECKS=1');
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async saveOne({ typeId, questionId, instructionId, isActive, paragraphTitle, question}) {
-    if (typeId == 2) {
-      return await this.db.executeQuery(` UPDATE question
-      SET instruction_id = ${instructionId}, is_active = ${isActive}, paragraph_title = '${paragraphTitle}'
-      WHERE question_id = ${questionId};`)
-    } else {
-      return await this.db.executeQuery(` UPDATE question
-      SET instruction_id = ${instructionId}, is_active = ${isActive},
-      question = '${question}'
-      WHERE question_id = ${questionId};`)
+    try {
+      let values;
+      if (typeId == 2) {
+        [values] = await this.Question.update({
+          instruction_id: instructionId,
+          is_active: isActive,
+          paragraph_title: paragraphTitle
+        }, { where: { question_id: questionId } });
+      } else {
+        [values] = await this.Question.update({
+          instruction_id: instructionId,
+          is_active: isActive,
+          question
+        }, { where: { question_id: questionId } });
+      }
+      return { error: null, response: { affectedRows: values } };
+    } catch (error) {
+      return { error };
     }
 
   }

--- a/server/models/question.js
+++ b/server/models/question.js
@@ -1,4 +1,4 @@
-const { DataTypes, QueryTypes } = require('sequelize');
+const { DataTypes, fn, col } = require('sequelize');
 const sequelize = require('../config/orm');
 
 const Question = sequelize.define('question', {
@@ -110,19 +110,23 @@ class QuestionModel {
 
   async loadContent(quizId) {
     try {
-      const res = await sequelize.query(
-        `SELECT q.question_id, qmc.choice_id, qmc.choice_text, qgf.sequence_id , qms.letter, qms.subquestion_id, qms.text, qmc.is_correct_choice, qms.column_assigned
-      FROM question q
-      JOIN quiz_question qq ON qq.question_id = q.question_id
-      JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-      LEFT JOIN question_multiple_choice qmc ON q.question_id =  qmc.question_id
-      LEFT JOIN question_gap_filling qgf ON q.question_id = qgf.question_id
-      LEFT JOIN question_matching_sub qms ON q.question_id = qms.question_id
-      WHERE qq.quiz_id = :quizId AND q.is_active = 1
-      ORDER BY q.question_id, qmc.choice_id, qgf.sequence_id, qms.subquestion_id`,
-        { replacements: { quizId }, type: QueryTypes.SELECT }
-      );
-      return { error: null, response: res };
+      const res = await this.Question.findAll({
+        where: { is_active: 1 },
+        include: [
+          { model: QuizQuestion, where: { quiz_id: quizId }, attributes: [] },
+          { model: QuestionMultipleChoice, attributes: ['choice_id', 'choice_text', 'is_correct_choice'], required: false },
+          { model: QuestionGapFilling, attributes: ['sequence_id', 'correct_answer'], required: false },
+          { model: QuestionMatchingSub, attributes: ['letter', 'subquestion_id', 'text', 'column_assigned'], required: false }
+        ],
+        attributes: ['question_id'],
+        order: [
+          ['question_id', 'ASC'],
+          [QuestionMultipleChoice, 'choice_id', 'ASC'],
+          [QuestionGapFilling, 'sequence_id', 'ASC'],
+          [QuestionMatchingSub, 'subquestion_id', 'ASC']
+        ]
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
     } catch (error) {
       return { error };
     }
@@ -130,16 +134,22 @@ class QuestionModel {
 
   async findManyByQuizIdForEdit(quizId) {
     try {
-      const res = await sequelize.query(
-        `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
-        FROM question q
-        JOIN quiz_question qq ON qq.question_id = q.question_id
-        JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-        JOIN question_type qt ON q.type_id = qt.type_id
-        WHERE qq.quiz_id = :quizId
-        ORDER BY q.question_id`,
-        { replacements: { quizId }, type: QueryTypes.SELECT }
-      );
+      const qs = await this.Question.findAll({
+        include: [
+          { model: QuizQuestion, where: { quiz_id: quizId }, attributes: [] },
+          { model: QuestionInstruction, attributes: ['instruction'] },
+          { model: QuestionType, attributes: ['type_name'] }
+        ],
+        order: [['question_id', 'ASC']]
+      });
+      const res = qs.map(q => {
+        const obj = q.toJSON();
+        obj.instruction = obj.question_instruction.instruction;
+        obj.type_name = obj.question_type.type_name;
+        delete obj.question_instruction;
+        delete obj.question_type;
+        return obj;
+      });
       return { error: null, response: res };
     } catch (error) {
       return { error };
@@ -148,32 +158,32 @@ class QuestionModel {
 
   async findManyByQuizId({quizId, userId, attemptId}) {
     try {
+      const include = [
+        { model: QuizQuestion, where: { quiz_id: quizId }, attributes: [] },
+        { model: QuestionInstruction, attributes: ['instruction'] },
+        { model: QuestionType, attributes: ['type_name'] }
+      ];
       if (attemptId && userId) {
-        const res = await sequelize.query(
-          `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction, uaq.*
-            FROM question q
-            JOIN quiz_question qq ON qq.question_id = q.question_id
-            JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-            JOIN question_type qt ON q.type_id = qt.type_id
-            JOIN user_answer_question uaq ON uaq.question_id = q.question_id
-            WHERE uaq.quiz_id = :quizId AND q.is_active = 1 AND uaq.user_id = :userId AND uaq.attempt_id = :attemptId
-            ORDER BY q.question_id`,
-          { replacements: { quizId, userId, attemptId }, type: QueryTypes.SELECT }
-        );
-        return { error: null, response: res };
-      } else {
-        const res = await sequelize.query(
-          `SELECT q.question_id, q.type_id, qt.type_name, q.is_active, q.paragraph_title, q.question, qi.instruction
-            FROM question q
-            JOIN quiz_question qq ON qq.question_id = q.question_id
-            JOIN question_instruction qi ON q.instruction_id = qi.instruction_id
-            JOIN question_type qt ON q.type_id = qt.type_id
-            WHERE qq.quiz_id = :quizId AND q.is_active = 1
-            ORDER BY q.question_id`,
-          { replacements: { quizId }, type: QueryTypes.SELECT }
-        );
-        return { error: null, response: res };
+        include.push({
+          model: UserAnswerQuestion,
+          where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId },
+          required: false
+        });
       }
+      const qs = await this.Question.findAll({
+        where: { is_active: 1 },
+        include,
+        order: [['question_id', 'ASC']]
+      });
+      const res = qs.map(q => {
+        const obj = q.toJSON();
+        obj.instruction = obj.question_instruction.instruction;
+        obj.type_name = obj.question_type.type_name;
+        delete obj.question_instruction;
+        delete obj.question_type;
+        return obj;
+      });
+      return { error: null, response: res };
     } catch (error) {
       return { error };
     }
@@ -181,13 +191,11 @@ class QuestionModel {
 
   async findNumberOfQuestions() {
     try {
-      const res = await sequelize.query(
-        `SELECT quiz.quiz_id,
-    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS number_of_questions
-    FROM quiz`,
-        { type: QueryTypes.SELECT }
-      );
-      return { error: null, response: res };
+      const res = await QuizQuestion.findAll({
+        attributes: ['quiz_id', [sequelize.fn('COUNT', sequelize.col('question_id')), 'number_of_questions']],
+        group: ['quiz_id']
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
     } catch (error) {
       return { error };
     }

--- a/server/models/question_type.js
+++ b/server/models/question_type.js
@@ -1,12 +1,23 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuestionType = sequelize.define('question_type', {
+  type_id: { type: DataTypes.INTEGER, primaryKey: true },
+  type_name: DataTypes.STRING
+}, { tableName: 'question_type', timestamps: false });
 
 class QuestionTypeModel {
   constructor() {
-    this.db = database;
+    this.QuestionType = QuestionType;
   }
 
   async findAll() {
-    return await this.db.executeQuery(`SELECT * FROM question_type`);
+    try {
+      const res = await this.QuestionType.findAll();
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/quiz.js
+++ b/server/models/quiz.js
@@ -1,92 +1,188 @@
-const database = new (require("../config/database"))();
+const { DataTypes, literal, fn, col, Op } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const Quiz = sequelize.define('quiz', {
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  course_name: DataTypes.STRING,
+  skill_id: DataTypes.INTEGER,
+  description: DataTypes.TEXT,
+  is_active: DataTypes.BOOLEAN,
+  time_allowed: DataTypes.INTEGER,
+  created_by: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'quiz', timestamps: false });
+
+const QuizSkill = sequelize.define('quiz_skill', {
+  skill_id: { type: DataTypes.INTEGER, primaryKey: true },
+  skill_description: DataTypes.STRING
+}, { tableName: 'quiz_skill', timestamps: false });
+
+const UserAttempt = sequelize.define('user_attempt', {
+  user_id: DataTypes.INTEGER,
+  quiz_id: DataTypes.INTEGER,
+  attempt_id: DataTypes.INTEGER,
+  start_time: DataTypes.DATE,
+  end_time: DataTypes.DATE,
+  remaining_time: DataTypes.INTEGER,
+  grade: DataTypes.DECIMAL(5,2)
+}, { tableName: 'user_attempt', timestamps: false });
+
+const QuizQuestion = sequelize.define('quiz_question', {
+  quiz_id: DataTypes.INTEGER,
+  question_id: DataTypes.INTEGER
+}, { tableName: 'quiz_question', timestamps: false });
+
+const UserAnswerQuestion = sequelize.define('user_answer_question', {
+  quiz_id: DataTypes.INTEGER,
+  user_id: DataTypes.INTEGER,
+  attempt_id: DataTypes.INTEGER,
+  question_id: DataTypes.INTEGER
+}, { tableName: 'user_answer_question', timestamps: false });
+
+const UserFavorite = sequelize.define('user_favorite', {
+  user_id: DataTypes.INTEGER,
+  quiz_id: DataTypes.INTEGER
+}, { tableName: 'user_favorite', timestamps: false });
+
+const UserRating = sequelize.define('user_rating', {
+  user_id: DataTypes.INTEGER,
+  quiz_id: DataTypes.INTEGER,
+  rating_given: DataTypes.INTEGER
+}, { tableName: 'user_rating', timestamps: false });
+
+Quiz.belongsTo(QuizSkill, { foreignKey: 'skill_id' });
 
 class QuizModel {
   constructor() {
-    this.db = database;
+    this.Quiz = Quiz;
   }
 
   async findAllForTeacher() {
-    return await this.db.executeQuery(`SELECT quiz.*, quiz_skill.skill_description, 
-      (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-      (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS 'number_of_questions',
-      COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0) as average_rating,
-      COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0) as rating_count
-      FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id`);
+    try {
+      const quizzes = await Quiz.findAll({
+        include: [{ model: QuizSkill, attributes: ['skill_description'] }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id)'), 'attempts'],
+            [literal('(SELECT COUNT(*) FROM quiz_question WHERE quiz_question.quiz_id = quiz.quiz_id)'), 'number_of_questions'],
+            [literal('COALESCE((SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0.0)'), 'average_rating'],
+            [literal('COALESCE((SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id), 0)'), 'rating_count']
+          ]
+        }
+      });
+      const res = quizzes.map(q => {
+        const obj = q.toJSON();
+        obj.skill_description = obj.quiz_skill.skill_description;
+        delete obj.quiz_skill;
+        return obj;
+      });
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAll() {
-    return await this.db.executeQuery("SELECT * FROM quiz");
+    try {
+      const res = await Quiz.findAll();
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findLatestAttemptsForAllQuizzes(userId) {
-    return await this.db.execute(`
-    SELECT * FROM user_attempt ua1 INNER JOIN (SELECT quiz_id, MAX(attempt_id) as latest_attempt_id FROM user_attempt WHERE user_id = ${userId} GROUP BY quiz_id) ua2
-    ON ua1.quiz_id = ua2.quiz_id AND ua1.attempt_id = ua2.latest_attempt_id
-	WHERE user_id = ${userId} `);
+    try {
+      const latest = await UserAttempt.findAll({
+        where: { user_id: userId },
+        attributes: ['quiz_id', [fn('MAX', col('attempt_id')), 'latest_attempt_id']],
+        group: ['quiz_id'],
+        raw: true
+      });
+      const attempts = await Promise.all(latest.map(l =>
+        UserAttempt.findOne({ where: { user_id: userId, quiz_id: l.quiz_id, attempt_id: l.latest_attempt_id } })
+      ));
+      return { error: null, response: attempts.filter(a => a).map(a => a.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findDetailed(quizId) {
-    return await this.db
-      .executeQuery(`SELECT quiz.*, quiz_skill.skill_description, 
-    (SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id) as attempts,
-    (SELECT COUNT(*) FROM quiz_question WHERE quiz.quiz_id = quiz_question.quiz_id) AS 'number_of_questions',
-    (SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id) as average_rating,
-    (SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id) as rating_count
-    FROM quiz JOIN quiz_skill ON quiz.skill_id = quiz_skill.skill_id
-    WHERE quiz.quiz_id = ${quizId}`);
+    try {
+      const quiz = await Quiz.findOne({
+        where: { quiz_id: quizId },
+        include: [{ model: QuizSkill, attributes: ['skill_description'] }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM user_attempt WHERE user_attempt.quiz_id = quiz.quiz_id)'), 'attempts'],
+            [literal('(SELECT COUNT(*) FROM quiz_question WHERE quiz_question.quiz_id = quiz.quiz_id)'), 'number_of_questions'],
+            [literal('(SELECT AVG(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id)'), 'average_rating'],
+            [literal('(SELECT COUNT(user_rating.rating_given) FROM user_rating WHERE user_rating.quiz_id = quiz.quiz_id GROUP BY quiz_id)'), 'rating_count']
+          ]
+        }
+      });
+      return { error: null, response: quiz ? [quiz.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(id) {
-    return await this.db.executeQuery(
-      `SELECT (SELECT CONCAT(u.first_name, ' ', u.last_name)) as full_name, dp.created_at as posted_at, u.created_at as member_since, dp.content, 
-      (SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = u.user_id) as thread_count,
-      (SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = u.user_id) as post_count
-      FROM discussion_post dp JOIN user u ON dp.user_id = u.user_id
-      WHERE dp.post_id = ${id}`
-    );
+    try {
+      const quiz = await Quiz.findByPk(id);
+      return { error: null, response: quiz ? [quiz.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
-  async addOne({
-    courseName,
-    description,
-    isActive,
-    timeAllowed,
-    skillId,
-    userId,
-  }) {
-    return await this.db
-      .executeQuery(`INSERT INTO quiz (course_name, description, is_active, time_allowed, skill_id, created_by) 
-    VALUES ('${courseName}', '${description}', '${isActive}', '${timeAllowed}', '${skillId}', '${userId}')`);
+  async addOne({ courseName, description, isActive, timeAllowed, skillId, userId }) {
+    try {
+      const res = await Quiz.create({
+        course_name: courseName,
+        description,
+        is_active: isActive,
+        time_allowed: timeAllowed,
+        skill_id: skillId,
+        created_by: userId
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
-  async saveOne({
-    quizId,
-    courseName,
-    description,
-    isActive,
-    timeAllowed,
-    skillId,
-    userId,
-  }) {
-    return await this.db.executeQuery(`UPDATE quiz 
-    SET course_name = '${courseName}', 
-        description = '${description}', 
-        is_active = '${isActive}', 
-        time_allowed = '${timeAllowed}', 
-        skill_id = '${skillId}', 
-        created_by = '${userId}'
-    WHERE quiz_id = '${quizId}'`);
+  async saveOne({ quizId, courseName, description, isActive, timeAllowed, skillId, userId }) {
+    try {
+      const [rows] = await Quiz.update({
+        course_name: courseName,
+        description,
+        is_active: isActive,
+        time_allowed: timeAllowed,
+        skill_id: skillId,
+        created_by: userId
+      }, { where: { quiz_id: quizId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(quizId) {
-    return await this.db.executeQuery(`SET FOREIGN_KEY_CHECKS=0;
-    DELETE FROM user_answer_question WHERE quiz_id = ${quizId};
-    DELETE FROM user_attempt WHERE quiz_id = ${quizId};
-    DELETE FROM user_favorite WHERE quiz_id = ${quizId};
-    DELETE FROM user_rating WHERE quiz_id = ${quizId};
-    DELETE FROM quiz_question WHERE quiz_id = ${quizId};
-    DELETE FROM quiz WHERE quiz_id = ${quizId};
-    SET FOREIGN_KEY_CHECKS=1`);
+    try {
+      await sequelize.transaction(async t => {
+        await UserAnswerQuestion.destroy({ where: { quiz_id: quizId }, transaction: t });
+        await UserAttempt.destroy({ where: { quiz_id: quizId }, transaction: t });
+        await UserFavorite.destroy({ where: { quiz_id: quizId }, transaction: t });
+        await UserRating.destroy({ where: { quiz_id: quizId }, transaction: t });
+        await QuizQuestion.destroy({ where: { quiz_id: quizId }, transaction: t });
+        await Quiz.destroy({ where: { quiz_id: quizId }, transaction: t });
+      });
+      return { error: null, response: { affectedRows: 1 } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/quiz_question.js
+++ b/server/models/quiz_question.js
@@ -1,21 +1,32 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuizQuestion = sequelize.define('quiz_question', {
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true }
+}, { tableName: 'quiz_question', timestamps: false });
 
 class QuizQuestionModel {
   constructor() {
-    this.db = database;
+    this.QuizQuestion = QuizQuestion;
   }
 
   async addOne(quizId, questionId) {
-    return await this.db.executeQuery(`
-    INSERT INTO quiz_question (quiz_id, question_id)
-    VALUES ('${quizId}', '${questionId}')
-    `);
+    try {
+      const res = await this.QuizQuestion.create({ quiz_id: quizId, question_id: questionId });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(quizId, questionId) {
-    return await this.db.executeQuery(
-      `SELECT quiz_id, question_id FROM quiz_question WHERE quiz_id = ${quizId} AND question_id = ${questionId}`
-    );
+    try {
+      const res = await this.QuizQuestion.findOne({ where: { quiz_id: quizId, question_id: questionId } });
+      return { error: null, response: res ? [res.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/rating.js
+++ b/server/models/rating.js
@@ -1,43 +1,97 @@
-const database = new (require("../config/database"))();
+const { DataTypes, QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const UserRating = sequelize.define('user_rating', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  rating_given: DataTypes.INTEGER
+}, { tableName: 'user_rating', timestamps: false });
 
 class RatingModel {
   constructor() {
-    this.db = database;
+    this.UserRating = UserRating;
   }
 
   async findOne(quizId, userId) {
-    return await this.db.executeQuery(`SELECT rating_given FROM user_rating
-    WHERE user_rating.user_id = ${userId} AND user_rating.quiz_id = ${quizId}`)  
+    try {
+      const rating = await this.UserRating.findOne({
+        where: { quiz_id: quizId, user_id: userId },
+        attributes: ['rating_given']
+      });
+      return { error: null, response: rating ? [rating.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOneByQuizId(quizId, userId) {
-    return await this.db.executeQuery(`SELECT COALESCE((SELECT COUNT(ur.rating_given) FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = ${quizId}), 0) AS rating_count,
-    COALESCE((SELECT AVG(ur.rating_given) FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = ${quizId} GROUP BY q.quiz_id), 0.0) AS average_rating,
-    COALESCE((SELECT ur.rating_given FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = ${quizId}  AND ur.user_id = ${userId}), 0) as rating_given`)  
+    try {
+      const res = await sequelize.query(
+        `SELECT COALESCE((SELECT COUNT(ur.rating_given) FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = :quizId), 0) AS rating_count,
+        COALESCE((SELECT AVG(ur.rating_given) FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = :quizId GROUP BY q.quiz_id), 0.0) AS average_rating,
+        COALESCE((SELECT ur.rating_given FROM user_rating ur JOIN quiz q ON ur.quiz_id = q.quiz_id WHERE q.quiz_id = :quizId  AND ur.user_id = :userId), 0) as rating_given`,
+        { replacements: { quizId, userId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAll() {
-    return await this.db.executeQuery(`SELECT quiz_id, AVG(user_rating.rating_given) as average_rating, COUNT(user_rating.rating_given) as rating_count FROM user_rating GROUP BY quiz_id`);
+    try {
+      const res = await this.UserRating.findAll({
+        attributes: [
+          'quiz_id',
+          [sequelize.fn('AVG', sequelize.col('rating_given')), 'average_rating'],
+          [sequelize.fn('COUNT', sequelize.col('rating_given')), 'rating_count']
+        ],
+        group: ['quiz_id']
+      });
+      return { error: null, response: res.map(r => r.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async addOne({quizId, userId, ratingGiven}) {
-    return await this.db.executeQuery(`INSERT INTO user_rating (user_id, quiz_id, rating_given) VALUES ('${userId}', '${quizId}', '${ratingGiven}')`)
+    try {
+      const res = await this.UserRating.create({
+        user_id: userId,
+        quiz_id: quizId,
+        rating_given: ratingGiven
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async saveOne({quizId, userId, ratingGiven}) {
-    return await this.db.executeQuery(`UPDATE user_rating 
-    SET rating_given = '${ratingGiven}'
-    WHERE user_rating.user_id = ${userId} AND user_rating.quiz_id = ${quizId}`)
+    try {
+      const [rows] = await this.UserRating.update({ rating_given: ratingGiven }, { where: { user_id: userId, quiz_id: quizId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(quizId, userId) {
-    return await this.db.executeQuery(`DELETE FROM user_rating 
-    WHERE user_rating.user_id = ${userId} AND user_rating.quiz_id = ${quizId}`)
+    try {
+      const rows = await this.UserRating.destroy({ where: { user_id: userId, quiz_id: quizId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteAll(quizId) {
-    return await this.db.executeQuery(`DELETE FROM user_rating 
-    WHERE user_rating.quiz_id = ${quizId}`)
+    try {
+      const rows = await this.UserRating.destroy({ where: { quiz_id: quizId } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/skill.js
+++ b/server/models/skill.js
@@ -1,12 +1,23 @@
-const database = new (require("../config/database"))();
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const QuizSkill = sequelize.define('quiz_skill', {
+  skill_id: { type: DataTypes.INTEGER, primaryKey: true },
+  skill_description: DataTypes.STRING
+}, { tableName: 'quiz_skill', timestamps: false });
 
 class SkillModel {
   constructor() {
-    this.db = database;
+    this.QuizSkill = QuizSkill;
   }
 
   async findAll() {
-    return await this.db.executeQuery(`SELECT * FROM quiz_skill`);
+    try {
+      const skills = await this.QuizSkill.findAll();
+      return { error: null, response: skills.map(s => s.toJSON()) };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/statistics.js
+++ b/server/models/statistics.js
@@ -1,46 +1,83 @@
-const database = new (require("../config/database"))();
+const { QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
 
 class StatisticsModel {
-  constructor() {
-    this.db = database;
-  }
+  constructor() {}
 
   async findQuizOne(userId) {
-    return await this.db.executeQuery(`SELECT (SELECT COUNT(*) FROM (SELECT quiz_id FROM quiz  GROUP BY quiz_id) as T) as number_of_quizzes, 
-    (SELECT COUNT(*) FROM (SELECT * FROM user_attempt ua WHERE ua.user_id = ${userId} AND ua.end_time IS NULL) as Y) as incomplete,
-    (SELECT COUNT(*) FROM quiz q WHERE q.quiz_id NOT IN (SELECT quiz_id FROM user_attempt ua WHERE ua.user_id = ${userId} GROUP BY quiz_id)) as unattempted
-    
-    `)
+    try {
+      const res = await sequelize.query(
+        `SELECT (SELECT COUNT(*) FROM (SELECT quiz_id FROM quiz GROUP BY quiz_id) as T) as number_of_quizzes,
+        (SELECT COUNT(*) FROM (SELECT * FROM user_attempt ua WHERE ua.user_id = :userId AND ua.end_time IS NULL) as Y) as incomplete,
+        (SELECT COUNT(*) FROM quiz q WHERE q.quiz_id NOT IN (SELECT quiz_id FROM user_attempt ua WHERE ua.user_id = :userId GROUP BY quiz_id)) as unattempted`,
+        { replacements: { userId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAnswerOne(userId) {
-      return await this.db.executeQuery(`SELECT  
-      (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = ${userId} AND uaq.is_correct = 1) as correct,
-      (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = ${userId} AND uaq.is_correct = 2) as partially_correct,
-      (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = ${userId} AND uaq.is_correct = 3) as incorrect,
-      (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = ${userId} AND uaq.is_correct = 4) as unanswered`)
+      try {
+        const res = await sequelize.query(
+          `SELECT
+          (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = :userId AND uaq.is_correct = 1) as correct,
+          (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = :userId AND uaq.is_correct = 2) as partially_correct,
+          (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = :userId AND uaq.is_correct = 3) as incorrect,
+          (SELECT COUNT(*) FROM user_answer_question uaq WHERE uaq.user_id = :userId AND uaq.is_correct = 4) as unanswered`,
+          { replacements: { userId }, type: QueryTypes.SELECT }
+        );
+        return { error: null, response: res };
+      } catch (error) {
+        return { error };
+      }
   }
   async findBoardStatisticsByQuiz({quizId, dateFrom, dateTo}) {
-    return await this.db.executeQuery(`SELECT ua.end_time, ua.grade, CONCAT(u.first_name,  ' ', u.last_name) as full_name
-    FROM user_attempt ua JOIN user u ON ua.user_id = u.user_id
-    WHERE quiz_id = ${quizId} 
-      AND ua.end_time IS NOT NULL
-      AND (ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}')
-    ORDER BY grade DESC`)
+    try {
+      const res = await sequelize.query(
+        `SELECT ua.end_time, ua.grade, CONCAT(u.first_name,  ' ', u.last_name) as full_name
+        FROM user_attempt ua JOIN user u ON ua.user_id = u.user_id
+        WHERE quiz_id = :quizId
+          AND ua.end_time IS NOT NULL
+          AND (ua.end_time BETWEEN :dateFrom AND :dateTo)
+        ORDER BY grade DESC`,
+        { replacements: { quizId, dateFrom, dateTo }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findBoardStatisticsByAnswerQuality({userId, dateFrom, dateTo}) {
-    return await this.db.executeQuery(`SELECT  
-    (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = ${userId} AND (ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}') AND uaq.is_correct = 1) as correct,
-    (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = ${userId} AND (ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}') AND uaq.is_correct = 2) as partially_correct,
-    (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = ${userId} AND (ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}') AND uaq.is_correct = 3) as incorrect,
-    (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = ${userId} AND (ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}') AND uaq.is_correct = 4) as unanswered`)
+    try {
+      const res = await sequelize.query(
+        `SELECT
+        (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = :userId AND (ua.end_time BETWEEN :dateFrom AND :dateTo) AND uaq.is_correct = 1) as correct,
+        (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = :userId AND (ua.end_time BETWEEN :dateFrom AND :dateTo) AND uaq.is_correct = 2) as partially_correct,
+        (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = :userId AND (ua.end_time BETWEEN :dateFrom AND :dateTo) AND uaq.is_correct = 3) as incorrect,
+        (SELECT COUNT(*) FROM user_answer_question uaq JOIN user_attempt ua ON uaq.user_id = ua.user_id AND uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.attempt_id WHERE uaq.user_id = :userId AND (ua.end_time BETWEEN :dateFrom AND :dateTo) AND uaq.is_correct = 4) as unanswered`,
+        { replacements: { userId, dateFrom, dateTo }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findBoardStatisticsByQuizCompleted({userId, dateFrom, dateTo}) {
-    return await this.db.executeQuery(`SELECT (SELECT COUNT(*) FROM (SELECT quiz_id FROM quiz  GROUP BY quiz_id) as T) as number_of_quizzes, 
-    (SELECT COUNT(*) FROM (SELECT * FROM user_attempt ua WHERE ua.user_id = ${userId} AND ua.end_time IS NULL) as Y) as incomplete,
-    (SELECT COUNT(*) FROM quiz q WHERE q.quiz_id NOT IN (SELECT quiz_id FROM user_attempt ua WHERE ua.user_id = ${userId} AND ua.end_time BETWEEN '${dateFrom}' AND '${dateTo}' GROUP BY quiz_id)) as unattempted`)
+    try {
+      const res = await sequelize.query(
+        `SELECT (SELECT COUNT(*) FROM (SELECT quiz_id FROM quiz GROUP BY quiz_id) as T) as number_of_quizzes,
+        (SELECT COUNT(*) FROM (SELECT * FROM user_attempt ua WHERE ua.user_id = :userId AND ua.end_time IS NULL) as Y) as incomplete,
+        (SELECT COUNT(*) FROM quiz q WHERE q.quiz_id NOT IN (SELECT quiz_id FROM user_attempt ua WHERE ua.user_id = :userId AND ua.end_time BETWEEN :dateFrom AND :dateTo GROUP BY quiz_id)) as unattempted`,
+        { replacements: { userId, dateFrom, dateTo }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/thread.js
+++ b/server/models/thread.js
@@ -1,83 +1,153 @@
-const database = new (require("../config/database"))();
+const { DataTypes, Op, literal, fn, col } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const DiscussionThread = sequelize.define('discussion_thread', {
+  thread_id: { type: DataTypes.INTEGER, primaryKey: true },
+  subject: DataTypes.STRING,
+  content: DataTypes.TEXT,
+  is_deleted: DataTypes.BOOLEAN,
+  user_id: DataTypes.INTEGER,
+  quiz_id: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'discussion_thread', timestamps: false });
+
+const User = sequelize.define('user', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  first_name: DataTypes.STRING,
+  last_name: DataTypes.STRING,
+  profile_picture_id: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'user', timestamps: false });
+
+const MimeType = sequelize.define('mime_type', {
+  mime_id: { type: DataTypes.INTEGER, primaryKey: true },
+  image_url: DataTypes.STRING
+}, { tableName: 'mime_type', timestamps: false });
+
+const DiscussionPost = sequelize.define('discussion_post', {
+  post_id: { type: DataTypes.INTEGER, primaryKey: true },
+  thread_id: DataTypes.INTEGER,
+  created_at: DataTypes.DATE
+}, { tableName: 'discussion_post', timestamps: false });
+
+DiscussionThread.belongsTo(User, { foreignKey: 'user_id' });
+User.belongsTo(MimeType, { foreignKey: 'profile_picture_id' });
+DiscussionThread.hasMany(DiscussionPost, { foreignKey: 'thread_id' });
 
 class ThreadModel {
   constructor() {
-    this.db = database;
+    this.DiscussionThread = DiscussionThread;
   }
 
   async findAll() {
-    return await this.db
-      .executeQuery(`SELECT dt.subject, dt.thread_id, dt.content, dt.quiz_id, dt.user_id as thread_starter, 
-      u.first_name,
-    (SELECT COUNT(*) FROM discussion_post dp WHERE dp.thread_id = dt.thread_id) as replies,
-    COALESCE(
-    (SELECT dp.created_at FROM discussion_post dp WHERE dp.thread_id = dt.thread_id ORDER BY dp.created_at DESC LIMIT 1),
-    (SELECT dt.created_at FROM discussion_thread dt1 WHERE dt1.thread_id = dt.thread_id)
-    ) as last_activity,
-    mt.image_url as thread_starter_avatar_url
-    FROM discussion_thread dt JOIN user u ON dt.user_id = u.user_id
-    JOIN mime_type mt ON u.profile_picture_id = mt.mime_id
-    ORDER BY last_activity desc`);
+    try {
+      const threads = await DiscussionThread.findAll({
+        include: [{
+          model: User,
+          attributes: ['first_name'],
+          include: [{ model: MimeType, attributes: [['image_url', 'thread_starter_avatar_url']] }]
+        }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM discussion_post dp WHERE dp.thread_id = discussion_thread.thread_id)'), 'replies'],
+            [literal(`COALESCE((SELECT dp.created_at FROM discussion_post dp WHERE dp.thread_id = discussion_thread.thread_id ORDER BY dp.created_at DESC LIMIT 1), discussion_thread.created_at)`), 'last_activity']
+          ]
+        },
+        order: [[literal('last_activity'), 'DESC']]
+      });
+      const res = threads.map(t => {
+        const obj = t.toJSON();
+        obj.thread_starter = obj.user_id;
+        obj.thread_starter_avatar_url = obj.user ? obj.user.mime_type.thread_starter_avatar_url : null;
+        obj.first_name = obj.user ? obj.user.first_name : null;
+        delete obj.user;
+        return obj;
+      });
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findOne(id) {
-    return await this.db.executeQuery(
-      `SELECT dt.thread_id, dt.subject, dt.content, dt.created_at, 
-      (SELECT CONCAT(u.first_name, ' ', u.last_name)) as full_name,
-            (SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = u.user_id) as thread_count,
-            (SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = u.user_id) as post_count,
-            dt.is_deleted,
-      u.created_at as member_since, u.profile_picture_id, m.image_url as avatarUrl
-      FROM discussion_thread dt JOIN user u ON dt.user_id = u.user_id
-      JOIN mime_type m ON m.mime_id = u.profile_picture_id
-      WHERE dt.thread_id = ${id}`
-    );
+    try {
+      const thread = await DiscussionThread.findOne({
+        where: { thread_id: id },
+        include: [{
+          model: User,
+          attributes: [
+            [fn('CONCAT', col('user.first_name'), ' ', col('user.last_name')), 'full_name'],
+            [literal('(SELECT COUNT(*) FROM discussion_thread dt1 WHERE dt1.user_id = user.user_id)'), 'thread_count'],
+            [literal('(SELECT COUNT(*) FROM discussion_post dp1 WHERE dp1.user_id = user.user_id)'), 'post_count'],
+            ['created_at', 'member_since'],
+            'profile_picture_id'
+          ],
+          include: [{ model: MimeType, attributes: [['image_url', 'avatarUrl']] }]
+        }]
+      });
+      return { error: null, response: thread ? [thread.toJSON()] : [] };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findMany({ subject, quizId, userId, dateCreated }) {
-    const whereClause = [];
-    let formattedWhereClause = ''
-    if (subject) {
-      whereClause.push(`dt.subject LIKE '%${subject}%'`);
-    }
-    if (quizId) {
-      whereClause.push(`dt.quiz_id = ${quizId}`);
-    }
-    if (userId) {
-      whereClause.push(`dt.user_id = ${userId}`);
-    }
-    if (dateCreated) {
-      whereClause.push(`dt.created_at LIKE '${dateCreated}%'`);
-    }
+    try {
+      const where = {};
+      if (subject) where.subject = { [Op.like]: `%${subject}%` };
+      if (quizId) where.quiz_id = quizId;
+      if (userId) where.user_id = userId;
+      if (dateCreated) where.created_at = { [Op.like]: `${dateCreated}%` };
 
-    if (whereClause.length > 0) {
-      formattedWhereClause = 'WHERE ' + whereClause.join(" AND ")
+      const threads = await DiscussionThread.findAll({
+        where,
+        include: [{
+          model: User,
+          attributes: ['first_name'],
+          include: [{ model: MimeType, attributes: [['image_url', 'thread_starter_avatar_url']] }]
+        }],
+        attributes: {
+          include: [
+            [literal('(SELECT COUNT(*) FROM discussion_post dp WHERE dp.thread_id = discussion_thread.thread_id)'), 'replies'],
+            [literal(`COALESCE((SELECT dp.created_at FROM discussion_post dp WHERE dp.thread_id = discussion_thread.thread_id ORDER BY dp.created_at DESC LIMIT 1), discussion_thread.created_at)`), 'last_activity']
+          ]
+        }
+      });
+      const res = threads.map(t => {
+        const obj = t.toJSON();
+        obj.thread_starter = obj.user_id;
+        obj.thread_starter_avatar_url = obj.user ? obj.user.mime_type.thread_starter_avatar_url : null;
+        obj.first_name = obj.user ? obj.user.first_name : null;
+        delete obj.user;
+        return obj;
+      });
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
     }
-
-    return await this.db.executeQuery(
-      `SELECT dt.subject, dt.thread_id, dt.content, dt.quiz_id, dt.user_id as thread_starter, 
-        u.first_name,
-      (SELECT COUNT(*) FROM discussion_post dp WHERE dp.thread_id = dt.thread_id) as replies,
-      COALESCE(
-      (SELECT dp.created_at FROM discussion_post dp WHERE dp.thread_id = dt.thread_id ORDER BY dp.created_at DESC LIMIT 1),
-      (SELECT dt.created_at FROM discussion_thread dt1 WHERE dt1.thread_id = dt.thread_id)
-      ) as last_activity,
-      mt.image_url as thread_starter_avatar_url
-      FROM discussion_thread dt JOIN user u ON dt.user_id = u.user_id
-      JOIN mime_type mt ON u.profile_picture_id = mt.mime_id
-      ${formattedWhereClause}`
-    );
   }
 
-  async addOne({ subject, description, userId, selectedRelatedQuizId  }) {
-    return await this.db.executeQuery(`
-      INSERT INTO discussion_thread(subject, content, user_id, quiz_id) 
-      VALUES ('${subject}', '${description}', '${userId}', '${selectedRelatedQuizId}');
-      `);
+  async addOne({ subject, description, userId, selectedRelatedQuizId }) {
+    try {
+      const res = await DiscussionThread.create({
+        subject,
+        content: description,
+        user_id: userId,
+        quiz_id: selectedRelatedQuizId
+      });
+      return { error: null, response: { affectedRows: res ? 1 : 0 } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async deleteOne(id) {
-    return await this.db.executeQuery(`DELETE FROM discussion_thread WHERE thread_id = ${id}`)
+    try {
+      const rows = await DiscussionThread.destroy({ where: { thread_id: id } });
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 

--- a/server/models/user_answer.js
+++ b/server/models/user_answer.js
@@ -1,42 +1,89 @@
-const database = new (require("../config/database"))();
+const { DataTypes, QueryTypes } = require('sequelize');
+const sequelize = require('../config/orm');
+
+const UserAnswerQuestion = sequelize.define('user_answer_question', {
+  user_id: { type: DataTypes.INTEGER, primaryKey: true },
+  quiz_id: { type: DataTypes.INTEGER, primaryKey: true },
+  attempt_id: { type: DataTypes.INTEGER, primaryKey: true },
+  question_id: { type: DataTypes.INTEGER, primaryKey: true },
+  answer_text: DataTypes.STRING,
+  is_correct: DataTypes.INTEGER
+}, { tableName: 'user_answer_question', timestamps: false });
+
 
 class UserAnswerModel {
   constructor() {
-    this.db = database;
+    this.UserAnswerQuestion = UserAnswerQuestion;
   }
 
   async findAll({ quizId, userId, attemptId }) {
-    return await this.db.executeQuery(`SELECT ua.*, q.type_id
-    FROM user_answer_question ua JOIN question q ON q.question_id = ua.question_id
-    WHERE ua.quiz_id = ${quizId} AND ua.user_id = ${userId} AND ua.attempt_id = ${attemptId} AND q.is_active = 1
-    ORDER BY ua.question_id ASC`);
+    try {
+      const res = await sequelize.query(
+        `SELECT ua.*, q.type_id
+         FROM user_answer_question ua JOIN question q ON q.question_id = ua.question_id
+         WHERE ua.quiz_id = :quizId AND ua.user_id = :userId AND ua.attempt_id = :attemptId AND q.is_active = 1
+         ORDER BY ua.question_id ASC`,
+        { replacements: { quizId, userId, attemptId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async findAllAssociatedWithLatestAttempts({ userId }) {
-    return await this.db
-      .executeQuery(`SELECT * FROM user_answer_question uaq INNER JOIN (SELECT quiz_id, MAX(attempt_id) as latest_attempt_id FROM user_attempt WHERE user_id = ${userId} GROUP BY quiz_id) ua
-    ON uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.latest_attempt_id
-	WHERE user_id = ${userId} `);
+    try {
+      const res = await sequelize.query(
+        `SELECT * FROM user_answer_question uaq INNER JOIN
+          (SELECT quiz_id, MAX(attempt_id) as latest_attempt_id FROM user_attempt WHERE user_id = :userId GROUP BY quiz_id) ua
+          ON uaq.quiz_id = ua.quiz_id AND uaq.attempt_id = ua.latest_attempt_id
+        WHERE uaq.user_id = :userId`,
+        { replacements: { userId }, type: QueryTypes.SELECT }
+      );
+      return { error: null, response: res };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async closeOne({ quizId, userId, attemptId, grade }) {
-    return await this.db.executeQuery(``);
+    try {
+      const [rows] = await this.UserAnswerQuestion.update(
+        { is_correct: grade },
+        { where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId } }
+      );
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 
   async markOne(items) {
-    let query = ""
-
-    for ( const {quizId, userId, attemptId, questionId, markedResult} of items) {
-      query += `UPDATE user_answer_question SET is_correct = ${markedResult} WHERE user_id = ${userId} AND quiz_id = ${quizId} AND attempt_id = ${attemptId} AND question_id = ${questionId};\n`
+    try {
+      const promises = items.map(({ quizId, userId, attemptId, questionId, markedResult }) =>
+        this.UserAnswerQuestion.update(
+          { is_correct: markedResult },
+          { where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId, question_id: questionId } }
+        )
+      );
+      const results = await Promise.all(promises);
+      const affectedRows = results.reduce((sum, [rows]) => sum + rows, 0);
+      return { error: null, response: { affectedRows } };
+    } catch (error) {
+      return { error };
     }
-
-    return await this.db.executeQuery(query);
   }
 
   async saveOne({ quizId, userId, attemptId, questionId, answerText }) {
-    return await this.db.executeQuery(`UPDATE user_answer_question
-    SET answer_text = '${answerText}'
-    WHERE quiz_id = ${quizId} AND user_id = ${userId} AND attempt_id = ${attemptId} AND question_id = ${questionId}`);
+    try {
+      const [rows] = await this.UserAnswerQuestion.update(
+        { answer_text: answerText },
+        { where: { quiz_id: quizId, user_id: userId, attempt_id: attemptId, question_id: questionId } }
+      );
+      return { error: null, response: { affectedRows: rows } };
+    } catch (error) {
+      return { error };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- replace manual SQL in `QuestionModel` with Sequelize
- add model definitions and associations for questions and related tables

## Testing
- `npm test` *(fails: missing database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6850a12557bc8330b5b1e00901a4dd43