### PR TITLE
Add matching models and update quiz marking

### DIFF
--- a/server/api/controllers/questions.ts
+++ b/server/api/controllers/questions.ts
@@ -5,7 +5,8 @@ const QuizQuestionModel = require("../../new_models/QuizQuestionModel.ts").defau
 const QuestionModel = require("../../new_models/QuestionModel.ts").default;
 const MCModel = require("../../new_models/QuestionMultipleChoiceModel.ts").default;
 const GModel = require("../../new_models/QuestionGapFillingModel.ts").default;
-const MModel = require("../../new_models/QuestionMatchingPairModel.ts").default;
+const PromptModel = require("../../new_models/MatchingPromptModel.ts").default;
+const ChoiceModel = require("../../new_models/MatchingChoiceModel.ts").default;
 const AttemptModel = require("../../new_models/UserAttemptModel.ts").default;
 const InstructionModel = require("../../new_models/QuestionInstructionModel.ts").default;
 const validator = require("../validators/validator");
@@ -44,20 +45,20 @@ async function createQuestionContent(
       await GModel.createMany(data);
       return sendSuccess(201);
     } else if (typeId === 3) {
-      const pairs = [];
       const left = items.leftItems || [];
       const right = items.rightItems || [];
-      for (let i = 0; i < Math.max(left.length, right.length); i++) {
-        pairs.push({
-          QuestionId: questionId,
-          LeftText: left[i] ? left[i].item : '',
-          RightText: right[i] ? right[i].item : '',
-          PairOrder: i + 1,
-        });
-      }
-      if (pairs.length > 0) {
-        await MModel.createMany(pairs);
-      }
+      const prompts = left.map((l, idx) => ({
+        QuestionId: questionId,
+        LeftText: l.item,
+        PromptOrder: idx + 1,
+      }));
+      const choices = right.map((r, idx) => ({
+        QuestionId: questionId,
+        RightText: r.item,
+        ChoiceOrder: idx + 1,
+      }));
+      if (prompts.length > 0) await PromptModel.createMany(prompts);
+      if (choices.length > 0) await ChoiceModel.createMany(choices);
       return sendSuccess(201);
     }
   } catch (error) {

--- a/server/api/controllers/quizzes.ts
+++ b/server/api/controllers/quizzes.ts
@@ -346,18 +346,31 @@ module.exports = {
       let markedResult
 
       for (const { answer_text, type_id, question_id } of userAnswers) {
-        const corrects = type_id === 3 ?  correctAnswers[question_id][0].correct_answers.split(" ") .map((a) => a.split(".")) : correctAnswers[question_id]
+        const corrects = correctAnswers[question_id]
 
         if (answer_text === "") {
           result.unanswered += 1;
-          markedResult = 4
+          markedResult = 4;
 
           if (type_id === 1) {
-            response.detailedAnswers.push({answers: corrects.map(c => ({...c, marked: 0 === c.is_correct_choice, user_answer: 0}))})
+            response.detailedAnswers.push({ answers: corrects.map(c => ({ ...c, marked: 0 === c.is_correct_choice, user_answer: 0 })) });
           } else if (type_id === 2) {
-            response.detailedAnswers.push({answers: corrects })
+            response.detailedAnswers.push({ answers: corrects });
           } else if (type_id === 3) {
-            response.detailedAnswers.push({answers: corrects.map((c,i) => ({ type_id: 3, sequence_id: i + 1, correct_answer: c[1]}))})
+            const map: Record<number, string[]> = {};
+            for (const c of corrects) {
+              const po = c.prompt_order ?? c.PromptOrder;
+              const co = c.choice_order ?? c.ChoiceOrder;
+              const isCorrect = c.is_correct_choice === 1 || c.is_correct === 1 || c.is_correct_choice === true || c.is_correct === true;
+              if (isCorrect) {
+                if (!map[po]) map[po] = [];
+                map[po].push(String.fromCharCode(64 + co));
+              }
+            }
+            const orders = Object.keys(map).map(n => Number(n)).sort((a,b) => a - b);
+            response.detailedAnswers.push({
+              answers: orders.map(o => ({ type_id: 3, sequence_id: o, correct_answer: map[o].join('/') }))
+            });
 
           }
         } else {
@@ -424,27 +437,45 @@ module.exports = {
               result.partial += 1
             }
           } else if (type_id === 3) {
-            const answers = answer_text.split(" ").map((a) => a.split("."));
-            const marked = answers.map((item, i) => item[1] === corrects[i][1])
+            const map: Record<number, string[]> = {};
+            for (const c of corrects) {
+              const po = c.prompt_order ?? c.PromptOrder;
+              const co = c.choice_order ?? c.ChoiceOrder;
+              const isCorrect = c.is_correct_choice === 1 || c.is_correct === 1 || c.is_correct_choice === true || c.is_correct === true;
+              if (isCorrect) {
+                if (!map[po]) map[po] = [];
+                map[po].push(String.fromCharCode(64 + co));
+              }
+            }
+            const orders = Object.keys(map).map(n => Number(n)).sort((a,b) => a - b);
 
-            response.detailedAnswers[index].answers = corrects.map(c => ({ correct_answer: c[1]}))
-            
-            for (let i = 0; i < marked.length; i++) {
-              response.detailedAnswers[index].answers[i].type_id = 3
-              response.detailedAnswers[index].answers[i].sequence_id = i + 1
-              response.detailedAnswers[index].answers[i].user_answer = answers[i][1]
-              response.detailedAnswers[index].answers[i].marked = marked[i]
+            const answers = answer_text.split(" ").map(a => a.split("."));
+            const marks: boolean[] = [];
+            response.detailedAnswers[index].answers = [];
+            for (let i = 0; i < orders.length; i++) {
+              const po = orders[i];
+              const userChoice = answers[i] ? answers[i][1] : '';
+              const correctLetters = map[po] || [];
+              const isCorrect = userChoice && correctLetters.includes(userChoice);
+              marks.push(isCorrect);
+              response.detailedAnswers[index].answers.push({
+                type_id: 3,
+                sequence_id: po,
+                correct_answer: correctLetters.join('/'),
+                user_answer: userChoice,
+                marked: isCorrect
+              });
             }
 
-            if (marked.length === corrects.length && marked.every(m => m === true)) {
+            if (marks.length === orders.length && marks.every(m => m)) {
               markedResult = 1;
-              result.correct += 1
-            } else if (marked.every(m => m === false)) {
-              markedResult = 2
-              result.incorrect += 1
+              result.correct += 1;
+            } else if (marks.every(m => !m)) {
+              markedResult = 2;
+              result.incorrect += 1;
             } else {
-              markedResult = 3
-              result.partial += 1
+              markedResult = 3;
+              result.partial += 1;
             }
           }
         }

--- a/server/api/controllers/quizzes.ts
+++ b/server/api/controllers/quizzes.ts
@@ -1,7 +1,5 @@
 const STRINGS = require("../../config/strings");
 const { sendSuccess, sendFailure } = require("../../config/res");
-const helper = require("../../misc/helper");
-const { datetime_format } = require("../../config/index");
 const moment = require("moment");
 const QuizModel = require("../../new_models/QuizModel.ts").default;
 const RatingModel = require("../../new_models/UserRatingModel.ts").default;
@@ -333,16 +331,20 @@ module.exports = {
     }
 
     const endTime = moment(Date.now());
-    const getCorrectAnswers = await CorrectAnswerModel.findAll(qId);
-    const userAnswerQuestions = await UserAnswerModel.findAll({ quizId: qId, userId: uId, attemptId: aId });
-    const response = { detailedAnswers: [], result: [], grade: null }
+    try {
+      const getCorrectAnswers = await CorrectAnswerModel.findAll(qId);
+      const uaRecords = await UserAnswerModel.findAllByAttempt(qId, uId, aId);
+      const userAnswers = uaRecords.map((ua) => ({
+        answer_text: ua.AnswerText,
+        question_id: ua.QuestionId,
+        type_id: ua.Question.TypeId,
+      }));
+      const response = { detailedAnswers: [], result: [], grade: null };
 
-    if (!getCorrectAnswers.error && !userAnswerQuestions.error) {
       // 1 - correct, 2 - partially correct, 3 - incorrect, 4 - unanswered
       const result = { correct: 0, partial: 0, incorrect: 0, unanswered: 0 };
-      const correctAnswers = convertToObject( cleanObject(getCorrectAnswers.response) );
-      const userAnswers = userAnswerQuestions.response;
-      const userAnswersModels = []
+      const correctAnswers = convertToObject(cleanObject(getCorrectAnswers));
+      const userAnswersModels = [];
       let markedResult
 
       for (const { answer_text, type_id, question_id } of userAnswers) {
@@ -486,31 +488,29 @@ module.exports = {
       }
 
       const numQuestions = Object.keys(correctAnswers).length;
-      const eachQuestionMark = 100 / numQuestions
-      const grade = result.correct === numQuestions ? 100 : (eachQuestionMark * result.correct + (eachQuestionMark / 2) * result.partial)
+      const eachQuestionMark = 100 / numQuestions;
+      const grade =
+        result.correct === numQuestions
+          ? 100
+          : eachQuestionMark * result.correct + (eachQuestionMark / 2) * result.partial;
 
-      const updateMarked = await UserAnswerModel.markOne(userAnswersModels)
-      const attemptData = { endTime: endTime.format(datetime_format), grade };
-      const closeAttempt = await AttemptModel.closeOne(aId, attemptData)
-      const thisAttempt = await AttemptModel.findOne(qId, uId, aId)
+      await UserAnswerModel.markOne(userAnswersModels);
+      const attemptData = { EndTime: endTime.toDate(), Grade: grade };
+      await AttemptModel.closeOne(aId, attemptData);
+      const thisAttempt = await AttemptModel.findOne(qId, uId, aId);
 
-      if(!updateMarked.error && !closeAttempt.error && !thisAttempt.error) {
-        response.result = result
-        response.result.total = numQuestions
-        response.accuracy = grade
-        response.quiz_id = qId
-        response.attempt_id = aId
-        response.userAnswers = userAnswers
-        response.time_taken = endTime.diff(thisAttempt.response[0].start_time, 'seconds')
-  
-        return sendSuccess(response)
-      } else {
-        return sendFailure(STRINGS.ERROR_OCCURRED)
-      }
-    } else {
-      console.log(getCorrectAnswers.error)
-      console.log(userAnswerQuestions.error)
-      return sendFailure(STRINGS.ERROR_OCCURRED)
+      response.result = result;
+      response.result.total = numQuestions;
+      response.accuracy = grade;
+      response.quiz_id = qId;
+      response.attempt_id = aId;
+      response.userAnswers = userAnswers;
+      response.time_taken = endTime.diff(thisAttempt?.StartTime, 'seconds');
+
+      return sendSuccess(response);
+    } catch (error) {
+      console.log(error);
+      return sendFailure(STRINGS.ERROR_OCCURRED);
     }
   },
 };

--- a/server/api/controllers/teacher.ts
+++ b/server/api/controllers/teacher.ts
@@ -7,7 +7,8 @@ const QuizModel = require("../../new_models/QuizModel.ts").default;
 const QuestionModel = require("../../new_models/QuestionModel.ts").default;
 const MCModel = require("../../new_models/QuestionMultipleChoiceModel.ts").default;
 const GModel = require("../../new_models/QuestionGapFillingModel.ts").default;
-const MModel = require("../../new_models/QuestionMatchingPairModel.ts").default;
+const PromptModel = require("../../new_models/MatchingPromptModel.ts").default;
+const ChoiceModel = require("../../new_models/MatchingChoiceModel.ts").default;
 const InstructionModel = require("../../new_models/QuestionInstructionModel.ts").default;
 const validator = require("../validators/validator");
 
@@ -65,7 +66,8 @@ async function updateQuestionContent(
     } else if (typeId === 2) {
       await GModel.updateMany(questionId, items);
     } else if (typeId === 3) {
-      await MModel.updateMany(questionId, [...items.leftItems, ...items.rightItems]);
+      await PromptModel.updateMany(questionId, items.leftItems || []);
+      await ChoiceModel.updateMany(questionId, items.rightItems || []);
     }
     return sendSuccess(201);
   } catch (error) {
@@ -89,14 +91,15 @@ async function getQuestionContent(id, typeId, questionData) {
       const content = await GModel.findManyByQuestion(id);
       return sendSuccess({ ...questionData, items: content });
     } else {
-      const pairs = await MModel.findManyByQuestion(id);
-      const leftItems = pairs.filter((p) => p.PairOrder % 2 === 1).map((p) => ({
-        letter: String.fromCharCode(64 + p.PairOrder),
+      const prompts = await PromptModel.findManyByQuestion(id);
+      const choices = await ChoiceModel.findManyByQuestion(id);
+      const leftItems = prompts.map((p) => ({
+        letter: String.fromCharCode(64 + p.PromptOrder),
         item: p.LeftText,
       }));
-      const rightItems = pairs.filter((p) => p.PairOrder % 2 === 0).map((p) => ({
-        letter: String.fromCharCode(64 + p.PairOrder),
-        item: p.RightText,
+      const rightItems = choices.map((c) => ({
+        letter: String.fromCharCode(64 + c.ChoiceOrder),
+        item: c.RightText,
       }));
       return sendSuccess({ items: { leftItems, rightItems }, ...questionData });
     }

--- a/server/new_models/CorrectAnswerModel.ts
+++ b/server/new_models/CorrectAnswerModel.ts
@@ -2,11 +2,16 @@ import prisma from '../prismaClient';
 
 export class CorrectAnswerModel {
   static findAll(quizId: number) {
-    const query = `SELECT q.QuestionId, qmc.ChoiceText, qmc.ChoiceOrder as choice_id,
-      qmc.IsCorrect as is_correct_choice, qgf.SequenceId, qgf.CorrectAnswer,
-      mp.PromptOrder as prompt_order, mc.ChoiceOrder as choice_order,
-      CASE WHEN ma.ChoiceId IS NULL THEN 0 ELSE 1 END as is_correct,
-      q.TypeId
+    const query = `SELECT q.QuestionId as question_id,
+      q.TypeId as type_id,
+      qmc.ChoiceText as choice_text,
+      qmc.ChoiceOrder as choice_id,
+      qmc.IsCorrect as is_correct_choice,
+      qgf.SequenceId as sequence_id,
+      qgf.CorrectAnswer as correct_answer,
+      mp.PromptOrder as prompt_order,
+      mc.ChoiceOrder as choice_order,
+      CASE WHEN ma.ChoiceId IS NULL THEN 0 ELSE 1 END as is_correct
       FROM Question q
       JOIN QuizQuestion qq ON qq.QuestionId = q.QuestionId
       LEFT JOIN QuestionMultipleChoice qmc ON q.QuestionId = qmc.QuestionId

--- a/server/new_models/CorrectAnswerModel.ts
+++ b/server/new_models/CorrectAnswerModel.ts
@@ -2,16 +2,20 @@ import prisma from '../prismaClient';
 
 export class CorrectAnswerModel {
   static findAll(quizId: number) {
-    const query = `SELECT q.QuestionId, qmc.ChoiceText, qmc.ChoiceOrder as choice_id, qmc.IsCorrect as is_correct_choice,
-      qgf.SequenceId, qgf.CorrectAnswer, qmp.CorrectAnswers, q.TypeId
+    const query = `SELECT q.QuestionId, qmc.ChoiceText, qmc.ChoiceOrder as choice_id,
+      qmc.IsCorrect as is_correct_choice, qgf.SequenceId, qgf.CorrectAnswer,
+      mp.PromptOrder as prompt_order, mc.ChoiceOrder as choice_order,
+      CASE WHEN ma.ChoiceId IS NULL THEN 0 ELSE 1 END as is_correct,
+      q.TypeId
       FROM Question q
       JOIN QuizQuestion qq ON qq.QuestionId = q.QuestionId
-      JOIN QuestionInstruction qi ON q.InstructionId = qi.InstructionId
       LEFT JOIN QuestionMultipleChoice qmc ON q.QuestionId = qmc.QuestionId
       LEFT JOIN QuestionGapFilling qgf ON q.QuestionId = qgf.QuestionId
-      LEFT JOIN QuestionMatchingPair qmp ON q.QuestionId = qmp.QuestionId
+      LEFT JOIN MatchingPrompt mp ON q.QuestionId = mp.QuestionId
+      LEFT JOIN MatchingAnswer ma ON mp.PromptId = ma.PromptId
+      LEFT JOIN MatchingChoice mc ON ma.ChoiceId = mc.ChoiceId
       WHERE qq.QuizId = ${quizId} AND q.IsActive = 1
-      ORDER BY q.QuestionId, qmc.ChoiceOrder, qgf.SequenceId`;
+      ORDER BY q.QuestionId, qmc.ChoiceOrder, qgf.SequenceId, mp.PromptOrder, mc.ChoiceOrder`;
     return prisma.$queryRawUnsafe(query);
   }
 }

--- a/server/new_models/MatchingAnswerModel.ts
+++ b/server/new_models/MatchingAnswerModel.ts
@@ -18,6 +18,17 @@ export class MatchingAnswerModel {
     return prisma.matchingAnswer.delete({ where: { PromptId_ChoiceId: { PromptId, ChoiceId } } });
   }
 
+  static update(
+    PromptId: number,
+    ChoiceId: number,
+    data: Prisma.MatchingAnswerUpdateInput
+  ) {
+    return prisma.matchingAnswer.update({
+      where: { PromptId_ChoiceId: { PromptId, ChoiceId } },
+      data,
+    });
+  }
+
   static findAll() {
     return prisma.matchingAnswer.findMany();
   }

--- a/server/new_models/MatchingAnswerModel.ts
+++ b/server/new_models/MatchingAnswerModel.ts
@@ -1,0 +1,32 @@
+import prisma from '../prismaClient';
+import type { Prisma } from '@prisma/client';
+export interface MatchingAnswer {
+  PromptId: number;
+  ChoiceId: number;
+}
+
+export class MatchingAnswerModel {
+  static create(data: Prisma.MatchingAnswerCreateInput) {
+    return prisma.matchingAnswer.create({ data });
+  }
+
+  static createMany(data: Prisma.MatchingAnswerCreateManyInput[]) {
+    return prisma.matchingAnswer.createMany({ data });
+  }
+
+  static delete(PromptId: number, ChoiceId: number) {
+    return prisma.matchingAnswer.delete({ where: { PromptId_ChoiceId: { PromptId, ChoiceId } } });
+  }
+
+  static findAll() {
+    return prisma.matchingAnswer.findMany();
+  }
+
+  static findManyByQuestion(QuestionId: number) {
+    return prisma.matchingAnswer.findMany({
+      where: { MatchingPrompt: { QuestionId } },
+      include: { MatchingPrompt: true, MatchingChoice: true },
+    });
+  }
+}
+export default MatchingAnswerModel;

--- a/server/new_models/MatchingChoiceModel.ts
+++ b/server/new_models/MatchingChoiceModel.ts
@@ -1,0 +1,55 @@
+import prisma from '../prismaClient';
+import type { Prisma } from '@prisma/client';
+export interface MatchingChoice {
+  ChoiceId: number;
+  QuestionId: number;
+  RightText: string;
+  ChoiceOrder: number;
+}
+
+export class MatchingChoiceModel {
+  static create(data: Prisma.MatchingChoiceCreateInput) {
+    return prisma.matchingChoice.create({ data });
+  }
+
+  static createMany(data: Prisma.MatchingChoiceCreateManyInput[]) {
+    return prisma.matchingChoice.createMany({ data });
+  }
+
+  static findById(ChoiceId: number) {
+    return prisma.matchingChoice.findUnique({ where: { ChoiceId } });
+  }
+
+  static update(ChoiceId: number, data: Prisma.MatchingChoiceUpdateInput) {
+    return prisma.matchingChoice.update({ where: { ChoiceId }, data });
+  }
+
+  static delete(ChoiceId: number) {
+    return prisma.matchingChoice.delete({ where: { ChoiceId } });
+  }
+
+  static findAll() {
+    return prisma.matchingChoice.findMany();
+  }
+
+  static findManyByQuestion(QuestionId: number) {
+    return prisma.matchingChoice.findMany({
+      where: { QuestionId },
+      orderBy: { ChoiceOrder: 'asc' },
+    });
+  }
+
+  static async updateMany(
+    QuestionId: number,
+    items: { choice_order: number; right_text: string }[]
+  ) {
+    const queries = items.map((i) =>
+      prisma.matchingChoice.updateMany({
+        where: { QuestionId, ChoiceOrder: i.choice_order },
+        data: { RightText: i.right_text },
+      })
+    );
+    return prisma.$transaction(queries);
+  }
+}
+export default MatchingChoiceModel;

--- a/server/new_models/MatchingPromptModel.ts
+++ b/server/new_models/MatchingPromptModel.ts
@@ -1,0 +1,55 @@
+import prisma from '../prismaClient';
+import type { Prisma } from '@prisma/client';
+export interface MatchingPrompt {
+  PromptId: number;
+  QuestionId: number;
+  LeftText: string;
+  PromptOrder: number;
+}
+
+export class MatchingPromptModel {
+  static create(data: Prisma.MatchingPromptCreateInput) {
+    return prisma.matchingPrompt.create({ data });
+  }
+
+  static createMany(data: Prisma.MatchingPromptCreateManyInput[]) {
+    return prisma.matchingPrompt.createMany({ data });
+  }
+
+  static findById(PromptId: number) {
+    return prisma.matchingPrompt.findUnique({ where: { PromptId } });
+  }
+
+  static update(PromptId: number, data: Prisma.MatchingPromptUpdateInput) {
+    return prisma.matchingPrompt.update({ where: { PromptId }, data });
+  }
+
+  static delete(PromptId: number) {
+    return prisma.matchingPrompt.delete({ where: { PromptId } });
+  }
+
+  static findAll() {
+    return prisma.matchingPrompt.findMany();
+  }
+
+  static findManyByQuestion(QuestionId: number) {
+    return prisma.matchingPrompt.findMany({
+      where: { QuestionId },
+      orderBy: { PromptOrder: 'asc' },
+    });
+  }
+
+  static async updateMany(
+    QuestionId: number,
+    items: { prompt_order: number; left_text: string }[]
+  ) {
+    const queries = items.map((i) =>
+      prisma.matchingPrompt.updateMany({
+        where: { QuestionId, PromptOrder: i.prompt_order },
+        data: { LeftText: i.left_text },
+      })
+    );
+    return prisma.$transaction(queries);
+  }
+}
+export default MatchingPromptModel;

--- a/server/new_models/MatchingUserAnswerModel.ts
+++ b/server/new_models/MatchingUserAnswerModel.ts
@@ -1,0 +1,41 @@
+import prisma from '../prismaClient';
+import type { Prisma } from '@prisma/client';
+export interface MatchingUserAnswer {
+  UserAnswerId: number;
+  UserId: number;
+  QuestionId: number;
+  PromptId: number;
+  SelectedChoiceId: number;
+  AnsweredAt: Date;
+}
+
+export class MatchingUserAnswerModel {
+  static create(data: Prisma.MatchingUserAnswerCreateInput) {
+    return prisma.matchingUserAnswer.create({ data });
+  }
+
+  static createMany(data: Prisma.MatchingUserAnswerCreateManyInput[]) {
+    return prisma.matchingUserAnswer.createMany({ data });
+  }
+
+  static findById(UserAnswerId: number) {
+    return prisma.matchingUserAnswer.findUnique({ where: { UserAnswerId } });
+  }
+
+  static update(UserAnswerId: number, data: Prisma.MatchingUserAnswerUpdateInput) {
+    return prisma.matchingUserAnswer.update({ where: { UserAnswerId }, data });
+  }
+
+  static delete(UserAnswerId: number) {
+    return prisma.matchingUserAnswer.delete({ where: { UserAnswerId } });
+  }
+
+  static findAll() {
+    return prisma.matchingUserAnswer.findMany();
+  }
+
+  static findManyByUserAndQuestion(UserId: number, QuestionId: number) {
+    return prisma.matchingUserAnswer.findMany({ where: { UserId, QuestionId } });
+  }
+}
+export default MatchingUserAnswerModel;

--- a/server/new_models/QuestionModel.ts
+++ b/server/new_models/QuestionModel.ts
@@ -76,7 +76,8 @@ export class QuestionModel {
       include: {
         QuestionMultipleChoice: true,
         QuestionGapFilling: true,
-        QuestionMatchingPair: true,
+        MatchingPrompt: true,
+        MatchingChoice: true,
       },
       orderBy: { QuestionId: 'asc' },
     });
@@ -98,12 +99,18 @@ export class QuestionModel {
           correct_answer: g.CorrectAnswer,
         })
       );
-      q.QuestionMatchingPair.forEach((p) =>
+      q.MatchingPrompt.forEach((p) =>
         result.push({
           question_id: q.QuestionId,
-          pair_order: p.PairOrder,
+          prompt_order: p.PromptOrder,
           left_text: p.LeftText,
-          right_text: p.RightText,
+        })
+      );
+      q.MatchingChoice.forEach((c2) =>
+        result.push({
+          question_id: q.QuestionId,
+          choice_order: c2.ChoiceOrder,
+          right_text: c2.RightText,
         })
       );
     }

--- a/server/new_models/UserAnswerModel.ts
+++ b/server/new_models/UserAnswerModel.ts
@@ -49,13 +49,21 @@ export class UserAnswerModel {
     });
   }
 
-  static async markOne(items: { AttemptId: number; QuestionId: number; markedResult: number }[]) {
-    const queries = items.map((i) =>
-      prisma.userAnswer.updateMany({
-        where: { AttemptId: i.AttemptId, QuestionId: i.QuestionId },
-        data: { IsCorrect: i.markedResult },
-      })
-    );
+  static async markOne(items: { attemptId: number; questionId: number; markedResult: number }[]) {
+    const queries = items.map(({ attemptId, questionId, markedResult }) => {
+      let isCorrect: boolean | null;
+      if (markedResult === 1) {
+        isCorrect = true;
+      } else if (markedResult === 4) {
+        isCorrect = null;
+      } else {
+        isCorrect = false;
+      }
+      return prisma.userAnswer.updateMany({
+        where: { AttemptId: attemptId, QuestionId: questionId },
+        data: { IsCorrect: isCorrect },
+      });
+    });
     return prisma.$transaction(queries);
   }
 }


### PR DESCRIPTION
## Summary
- add CRUD models for MatchingPrompt, MatchingChoice, MatchingAnswer, MatchingUserAnswer
- update quiz submission logic for new matching question hierarchy

## Testing
- `npm test` *(fails: Prisma cannot connect)*

------
https://chatgpt.com/codex/tasks/task_e_68519055cbd08330a9d7bd12e3d54309