### PR TITLE
Fix vocabulary game timer and progress bar

### DIFF
--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -252,11 +252,14 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     
     if (correctCount === currentRound.relatedWords.length && incorrectCount === 0) {
       setFeedback(`Perfect! +${totalRoundScore} points`);
+      setIsPaused(true);
       setGameStats(prev => ({ ...prev, correctAnswers: prev.correctAnswers + 1 }));
     } else if (correctCount > incorrectCount) {
       setFeedback(`Good job! +${totalRoundScore} points`);
+      setIsPaused(true);
     } else {
       setFeedback(`Try harder next time. +${totalRoundScore} points`);
+      setIsPaused(true);
     }
 
     // Wait for user to close feedback
@@ -265,8 +268,9 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   // Handle time up
   const handleTimeUp = () => {
     if (!currentRound) return;
-    
+
     setFeedback('Time\'s up!');
+    setIsPaused(true);
     // Wait for user to close feedback
   };
 
@@ -311,6 +315,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
   const closeFeedback = () => {
     setFeedback(null);
+    setIsPaused(false);
     advanceRound();
   };
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -38,9 +38,9 @@ export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         <motion.div
           initial={{ width: 0 }}
           animate={{ width: `${percent}%` }}
-          transition={{ duration: 0.5, type: "spring" }}
+          transition={{ duration: 0.2, type: "tween", ease: "easeOut" }}
           className={cn(
-            "h-full rounded-2xl transition-all duration-300",
+            "h-full rounded-2xl transition-all duration-150",
             colorClass
           )}
         />


### PR DESCRIPTION
## Summary
- pause the Word Association Game timer when feedback is displayed
- resume timer when feedback is closed
- speed up progress bar transitions for quicker updates

## Testing
- `npm run lint` *(fails: ReferenceError: require is not defined in ES module scope)*
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6855467d01f48330b0031b72cebfe622