### PR TITLE
Update vocabulary game to use new lexicon columns

### DIFF
--- a/server/api/controllers/lexicon.ts
+++ b/server/api/controllers/lexicon.ts
@@ -34,6 +34,9 @@ export default {
         words: g.LexiconGroupMap.map((m) => ({
           expression: m.Lexicon.Word,
           meaning: m.Lexicon.Definition,
+          synonyms: m.Lexicon.Synonyms,
+          related: m.Lexicon.RelatedLexicon,
+          guideword: m.Lexicon.Guideword,
           type: m.Lexicon.LexiconType.TypeName,
         })),
       }));

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -39,6 +39,8 @@ interface GameRound {
   id: string;
   targetWord: string;
   targetMeaning?: string;
+  synonyms?: string[];
+  guidewords?: string[];
   relatedWords: string[];
   distractors: string[];
   allOptions: string[];
@@ -162,14 +164,11 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
       const parseList = (val?: string | null) =>
         val ? val.split(',').map((s) => s.trim()).filter(Boolean) : [];
 
-      const fromGroup = randomGroup.words
-        .filter((w) => w.text !== targetWord)
-        .map((w) => w.text);
       const synonyms = parseList(randomItem.synonyms);
       const related = parseList(randomItem.related);
       const guidewords = parseList(randomItem.guideword);
 
-      const relatedSet = Array.from(new Set([...fromGroup, ...synonyms, ...related, ...guidewords]));
+      const relatedSet = Array.from(new Set([...synonyms, ...related]));
       const relatedWords = relatedSet
         .filter((w) => w.toLowerCase() !== targetWord.toLowerCase())
         .sort(() => Math.random() - 0.5)
@@ -186,6 +185,9 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
       const newRound: GameRound = {
         id: `round-${roundNum}`,
         targetWord,
+        targetMeaning: randomItem.meaning,
+        synonyms,
+        guidewords,
         relatedWords,
         distractors: selectedDistractors,
         allOptions,
@@ -578,6 +580,11 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                 <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-2">
                   {currentRound.targetWord.toUpperCase()}
                 </div>
+                {currentRound.guidewords && currentRound.guidewords.length > 0 && (
+                  <div className="text-sm text-gray-500 dark:text-gray-400 mb-1">
+                    {currentRound.guidewords.join(', ')}
+                  </div>
+                )}
                 <Badge variant="secondary">
                   Theme: {currentRound.theme}
                 </Badge>
@@ -671,6 +678,21 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                             </Badge>
                           ))}
                         </div>
+                        {currentRound.targetMeaning && (
+                          <p className="mt-4">
+                            <strong>Definition:</strong> {currentRound.targetMeaning}
+                          </p>
+                        )}
+                        {currentRound.synonyms && currentRound.synonyms.length > 0 && (
+                          <p className="mt-2">
+                            <strong>Synonyms:</strong> {currentRound.synonyms.join(', ')}
+                          </p>
+                        )}
+                        {currentRound.guidewords && currentRound.guidewords.length > 0 && (
+                          <p className="mt-2">
+                            <strong>Guideword:</strong> {currentRound.guidewords.join(', ')}
+                          </p>
+                        )}
                       </div>
                     )}
                   </CardContent>

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -23,6 +23,9 @@ import {
 interface WordItem {
   text: string;
   meaning?: string;
+  synonyms?: string | null;
+  related?: string | null;
+  guideword?: string | null;
 }
 
 interface WordGroup {
@@ -79,7 +82,15 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
             .map((g: any) => ({
               ...g,
               words: g.words.map((w: any) =>
-                typeof w === 'string' ? { text: w } : { text: w.expression, meaning: w.meaning }
+                typeof w === 'string'
+                  ? { text: w }
+                  : {
+                      text: w.expression,
+                      meaning: w.meaning,
+                      synonyms: w.synonyms,
+                      related: w.related,
+                      guideword: w.guideword,
+                    }
               ),
             }))
             .filter((g: any) => g.words.length > 0);
@@ -147,15 +158,26 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
     if (mode === 'vocabulary') {
       const targetWord = randomItem.text;
-      const relatedWords = randomGroup.words
-        .filter(w => w.text !== targetWord)
-        .map(w => w.text)
+
+      const parseList = (val?: string | null) =>
+        val ? val.split(',').map((s) => s.trim()).filter(Boolean) : [];
+
+      const fromGroup = randomGroup.words
+        .filter((w) => w.text !== targetWord)
+        .map((w) => w.text);
+      const synonyms = parseList(randomItem.synonyms);
+      const related = parseList(randomItem.related);
+      const guidewords = parseList(randomItem.guideword);
+
+      const relatedSet = Array.from(new Set([...fromGroup, ...synonyms, ...related, ...guidewords]));
+      const relatedWords = relatedSet
+        .filter((w) => w.toLowerCase() !== targetWord.toLowerCase())
         .sort(() => Math.random() - 0.5)
         .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
 
       const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
       const selectedDistractors = distractorWords
-        .filter(w => w !== targetWord)
+        .filter((w) => w !== targetWord && !relatedSet.includes(w))
         .sort(() => Math.random() - 0.5)
         .slice(0, numDistractors);
 

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -168,7 +168,13 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
       const related = parseList(randomItem.related);
       const guidewords = parseList(randomItem.guideword);
 
-      const relatedSet = Array.from(new Set([...synonyms, ...related]));
+      let relatedSet = Array.from(new Set([...synonyms, ...related]));
+      if (relatedSet.length === 0) {
+        relatedSet = randomGroup.words
+          .filter((w) => w.text !== targetWord)
+          .map((w) => w.text);
+      }
+
       const relatedWords = relatedSet
         .filter((w) => w.toLowerCase() !== targetWord.toLowerCase())
         .sort(() => Math.random() - 0.5)
@@ -274,17 +280,18 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
     setScore(prev => prev + totalRoundScore);
     
+    let message = '';
     if (correctCount === currentRound.relatedWords.length && incorrectCount === 0) {
-      setFeedback(`Perfect! +${totalRoundScore} points`);
-      setIsPaused(true);
+      message = `Perfect! +${totalRoundScore} points`;
       setGameStats(prev => ({ ...prev, correctAnswers: prev.correctAnswers + 1 }));
-    } else if (correctCount > incorrectCount) {
-      setFeedback(`Good job! +${totalRoundScore} points`);
-      setIsPaused(true);
+    } else if (correctCount > 0 || incorrectCount > 0) {
+      message = `Partially correct. +${totalRoundScore} points`;
     } else {
-      setFeedback(`Try harder next time. +${totalRoundScore} points`);
-      setIsPaused(true);
+      message = `Better luck next time. +${totalRoundScore} points`;
     }
+
+    setFeedback(message);
+    setIsPaused(true);
 
     // Wait for user to close feedback
   };
@@ -596,13 +603,13 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                   <Lightbulb className="w-4 h-4 text-yellow-500" />
                   <span className="text-sm text-gray-600 dark:text-gray-400">
                     {mode === 'vocabulary'
-                      ? `Select ${currentRound.relatedWords.length} related words`
+                      ? `Select ${Math.max(1, currentRound.relatedWords.length)} related word${Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}`
                       : 'Select the correct meaning'}
                   </span>
                 </div>
                 {mode === 'vocabulary' && (
                   <div className="text-xs text-gray-500">
-                    Selected: {selectedWords.length} / {currentRound.relatedWords.length}
+                    Selected: {selectedWords.length} / {Math.max(1, currentRound.relatedWords.length)}
                   </div>
                 )}
               </div>
@@ -660,10 +667,18 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                 <Card onClick={e => e.stopPropagation()}>
                   <CardContent className="p-8 text-center">
                     <div className="mb-4">
-                      {feedback.includes('Perfect') && <Trophy className="w-12 h-12 text-yellow-500 mx-auto" />}
-                      {feedback.includes('Good') && <CheckCircle className="w-12 h-12 text-green-500 mx-auto" />}
-                      {feedback.includes('Try harder') && <XCircle className="w-12 h-12 text-red-500 mx-auto" />}
-                      {feedback.includes('Time\'s up') && <Clock className="w-12 h-12 text-orange-500 mx-auto" />}
+                      {feedback.includes('Perfect') && (
+                        <Trophy className="w-12 h-12 text-yellow-500 mx-auto" />
+                      )}
+                      {feedback.includes('Partially') && (
+                        <CheckCircle className="w-12 h-12 text-green-500 mx-auto" />
+                      )}
+                      {feedback.includes('Better luck') && (
+                        <XCircle className="w-12 h-12 text-red-500 mx-auto" />
+                      )}
+                      {feedback.includes("Time's up") && (
+                        <Clock className="w-12 h-12 text-orange-500 mx-auto" />
+                      )}
                     </div>
                     <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
                       {feedback}
@@ -673,7 +688,18 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                         <p className="mb-2">Correct answers were:</p>
                         <div className="flex flex-wrap gap-1 justify-center">
                           {currentRound.relatedWords.map(word => (
-                            <Badge key={word} variant="secondary">
+                            <Badge key={word} variant="success">
+                              {word}
+                            </Badge>
+                          ))}
+                        </div>
+                        <p className="mt-4 mb-2">Your selections:</p>
+                        <div className="flex flex-wrap gap-1 justify-center">
+                          {selectedWords.map(word => (
+                            <Badge
+                              key={word}
+                              variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}
+                            >
                               {word}
                             </Badge>
                           ))}


### PR DESCRIPTION
## Summary
- expose synonyms, related lexicon and guideword from `getGroups`
- include these fields when fetching groups on the client
- build related word set using synonyms/guidewords/related terms
- filter distractors to avoid related words

## Testing
- `npm run lint` *(fails: `ReferenceError: require is not defined in ES module scope`)*
- `npm test` *(fails: `ReferenceError: require is not defined in ES module scope`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68555e6d07088330a1b4f79d0778f461