### PR TITLE
Add synonyms and antonyms mode

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model AppLog {
-  LogId      Int      @id(map: "PK__AppLog__5E54864812B67847") @default(autoincrement())
+  LogId      Int      @id(map: "PK__AppLog__5E548648C17EF9A2") @default(autoincrement())
   LogLevel   String   @db.NVarChar(20)
   LogMessage String   @db.NVarChar(Max)
   UserId     Int?
@@ -18,8 +18,8 @@ model AppLog {
 }
 
 model AppUser {
-  UserId              Int                   @id(map: "PK__AppUser__1788CC4CBBA32B6F") @default(autoincrement())
-  Email               String                @unique(map: "UQ__AppUser__A9D105348101F4CF") @db.NVarChar(100)
+  UserId              Int                   @id(map: "PK__AppUser__1788CC4CC931A2A4") @default(autoincrement())
+  Email               String                @unique(map: "UQ__AppUser__A9D10534C5D1F73C") @db.NVarChar(100)
   PasswordHash        String?               @db.NVarChar(200)
   PasswordSalt        String?               @db.NVarChar(200)
   Gender              String                @default("U", map: "DF__AppUser__Gender__45F365D3") @db.Char(1)
@@ -44,7 +44,7 @@ model AppUser {
 }
 
 model AuditTrail {
-  AuditId         Int      @id(map: "PK__AuditTra__A17F2398DDB0D1B0") @default(autoincrement())
+  AuditId         Int      @id(map: "PK__AuditTra__A17F239891A6F2CD") @default(autoincrement())
   TableName       String   @db.NVarChar(100)
   RecordId        Int
   Action          String   @db.NVarChar(20)
@@ -56,7 +56,7 @@ model AuditTrail {
 }
 
 model Course {
-  CourseId             Int      @id(map: "PK__Course__C92D71A77596ED4A") @default(autoincrement())
+  CourseId             Int      @id(map: "PK__Course__C92D71A7B9E065C2") @default(autoincrement())
   Title                String   @db.NVarChar(200)
   Description          String?
   Level                String?  @db.NVarChar(20)
@@ -80,7 +80,7 @@ model Course {
 }
 
 model Lexicon {
-  LexiconId           Int                   @id(map: "PK__Lexicon__6AF595919B31B13A") @default(autoincrement())
+  LexiconId           Int                   @id(map: "PK__Lexicon__6AF59591BC8B5014") @default(autoincrement())
   Word                String                @db.NVarChar(100)
   Definition          String                @db.NVarChar(500)
   Example             String?
@@ -92,6 +92,7 @@ model Lexicon {
   Synonyms            String?               @db.NVarChar(500)
   Antonyms            String?               @db.NVarChar(500)
   RelatedLexicon      String?               @db.NVarChar(500)
+  Guideword           String?               @db.NVarChar(500)
   CreatedAt           DateTime              @default(dbgenerated("sysdatetime()"), map: "DF__Lexicon__Created__208CD6FA")
   TypeId              Int
   LexiconType         LexiconType           @relation(fields: [TypeId], references: [TypeId], onUpdate: NoAction, map: "FK_Lexicon_LexiconType")
@@ -100,7 +101,7 @@ model Lexicon {
 }
 
 model LexiconGroup {
-  GroupId         Int               @id(map: "PK__LexiconG__149AF36A6FFAC295") @default(autoincrement())
+  GroupId         Int               @id(map: "PK__LexiconG__149AF36A9D9801FD") @default(autoincrement())
   Theme           String            @db.NVarChar(100)
   Description     String?           @db.NVarChar(255)
   LexiconGroupMap LexiconGroupMap[]
@@ -112,12 +113,12 @@ model LexiconGroupMap {
   LexiconGroup LexiconGroup @relation(fields: [GroupId], references: [GroupId], onDelete: Cascade, onUpdate: NoAction, map: "FK_LexiconGroupMap_Group")
   Lexicon      Lexicon      @relation(fields: [LexiconId], references: [LexiconId], onDelete: Cascade, onUpdate: NoAction, map: "FK_LexiconGroupMap_Lexicon")
 
-  @@id([LexiconId, GroupId], map: "PK__LexiconG__DBBC3AA739E2DDBB")
+  @@id([LexiconId, GroupId], map: "PK__LexiconG__DBBC3AA7492D550E")
 }
 
 model LexiconType {
-  TypeId   Int       @id(map: "PK__LexiconT__516F03B55D9D9C83") @default(autoincrement())
-  TypeName String    @unique(map: "UQ__LexiconT__D4E7DFA863E95429") @db.NVarChar(50)
+  TypeId   Int       @id(map: "PK__LexiconT__516F03B5D1DD62FA") @default(autoincrement())
+  TypeName String    @unique(map: "UQ__LexiconT__D4E7DFA8A9F53683") @db.NVarChar(50)
   Lexicon  Lexicon[]
 }
 
@@ -127,11 +128,11 @@ model MatchingAnswer {
   MatchingChoice MatchingChoice @relation(fields: [ChoiceId], references: [ChoiceId], onUpdate: NoAction, map: "FK_MatchingAnswer_Choice")
   MatchingPrompt MatchingPrompt @relation(fields: [PromptId], references: [PromptId], onDelete: Cascade, onUpdate: NoAction, map: "FK_MatchingAnswer_Prompt")
 
-  @@id([PromptId, ChoiceId], map: "PK__Matching__3203F63968BC4215")
+  @@id([PromptId, ChoiceId], map: "PK__Matching__3203F639841A0D6C")
 }
 
 model MatchingChoice {
-  ChoiceId           Int                  @id(map: "PK__Matching__76F516A6BC179CE0") @default(autoincrement())
+  ChoiceId           Int                  @id(map: "PK__Matching__76F516A6B13A600B") @default(autoincrement())
   QuestionId         Int
   RightText          String               @db.NVarChar(255)
   ChoiceOrder        Int
@@ -141,7 +142,7 @@ model MatchingChoice {
 }
 
 model MatchingPrompt {
-  PromptId           Int                  @id(map: "PK__Matching__456CA753F384E44E") @default(autoincrement())
+  PromptId           Int                  @id(map: "PK__Matching__456CA7534BBAA14D") @default(autoincrement())
   QuestionId         Int
   LeftText           String               @db.NVarChar(255)
   PromptOrder        Int
@@ -151,7 +152,7 @@ model MatchingPrompt {
 }
 
 model MatchingUserAnswer {
-  UserAnswerId     Int            @id(map: "PK__Matching__47CE237FDA84CB95") @default(autoincrement())
+  UserAnswerId     Int            @id(map: "PK__Matching__47CE237F9FB93D66") @default(autoincrement())
   UserId           Int
   QuestionId       Int
   PromptId         Int
@@ -163,14 +164,14 @@ model MatchingUserAnswer {
 }
 
 model MimeType {
-  MimeId   Int       @id(map: "PK__MimeType__7AC4564523DF431F") @default(autoincrement())
-  ImageUrl String    @unique(map: "UQ__MimeType__372CE60D49352075") @db.NVarChar(255)
+  MimeId   Int       @id(map: "PK__MimeType__7AC45645A09CD7EC") @default(autoincrement())
+  ImageUrl String    @unique(map: "UQ__MimeType__372CE60DAA492C91") @db.NVarChar(255)
   ImageAlt String?   @db.NVarChar(255)
   AppUser  AppUser[]
 }
 
 model MockTest {
-  MockTestId      Int               @id(map: "PK__MockTest__069E78ABF29798FF") @default(autoincrement())
+  MockTestId      Int               @id(map: "PK__MockTest__069E78ABEC59E623") @default(autoincrement())
   Title           String            @db.NVarChar(200)
   Description     String?
   TotalDuration   Int
@@ -181,7 +182,7 @@ model MockTest {
 }
 
 model MockTestSection {
-  SectionId      Int       @id(map: "PK__MockTest__80EF08721FDA7489") @default(autoincrement())
+  SectionId      Int       @id(map: "PK__MockTest__80EF087276636C8C") @default(autoincrement())
   MockTestId     Int
   QuizId         Int?
   SkillId        Int
@@ -194,13 +195,13 @@ model MockTestSection {
 }
 
 model Permission {
-  PermissionId   Int              @id(map: "PK__Permissi__EFA6FB2FC4E045C1") @default(autoincrement())
-  PermissionName String           @unique(map: "UQ__Permissi__0FFDA35715284ACB") @db.NVarChar(100)
+  PermissionId   Int              @id(map: "PK__Permissi__EFA6FB2FC2CB13D2") @default(autoincrement())
+  PermissionName String           @unique(map: "UQ__Permissi__0FFDA357884240B9") @db.NVarChar(100)
   RolePermission RolePermission[]
 }
 
 model Question {
-  QuestionId             Int                      @id(map: "PK__Question__0DC06FAC465EC011") @default(autoincrement())
+  QuestionId             Int                      @id(map: "PK__Question__0DC06FAC48DAFA3E") @default(autoincrement())
   TypeId                 Int
   InstructionId          Int
   IsActive               Boolean                  @default(true, map: "DF__Question__IsActi__5CD6CB2B")
@@ -220,7 +221,7 @@ model Question {
 }
 
 model QuestionEssay {
-  QuestionId           Int      @id(map: "PK__Question__0DC06FACE17AAE5D")
+  QuestionId           Int      @id(map: "PK__Question__0DC06FACB53FD612")
   WordLimit            Int?
   SuggestedTimeMinutes Int?
   ModelAnswer          String?  @db.NVarChar(Max)
@@ -228,7 +229,7 @@ model QuestionEssay {
 }
 
 model QuestionGapFilling {
-  QGFId         Int      @id(map: "PK__Question__CBEA8A16D7FE2C26") @default(autoincrement())
+  QGFId         Int      @id(map: "PK__Question__CBEA8A16F2E9B4DE") @default(autoincrement())
   QuestionId    Int
   SequenceId    Int
   CorrectAnswer String   @db.NVarChar(255)
@@ -236,13 +237,13 @@ model QuestionGapFilling {
 }
 
 model QuestionInstruction {
-  InstructionId Int        @id(map: "PK__Question__CE06947181E5CD7B") @default(autoincrement())
-  Instruction   String     @unique(map: "UQ__Question__EEDB4FE7FBCE47FB") @db.NVarChar(255)
+  InstructionId Int        @id(map: "PK__Question__CE0694713C3FC344") @default(autoincrement())
+  Instruction   String     @unique(map: "UQ__Question__EEDB4FE71DD94471") @db.NVarChar(255)
   Question      Question[]
 }
 
 model QuestionMultipleChoice {
-  QMCId       Int      @id(map: "PK__Question__FD853F8AC026D1EB") @default(autoincrement())
+  QMCId       Int      @id(map: "PK__Question__FD853F8A7ECEFB7F") @default(autoincrement())
   QuestionId  Int
   ChoiceText  String   @db.NVarChar(128)
   ChoiceOrder Int
@@ -251,13 +252,13 @@ model QuestionMultipleChoice {
 }
 
 model QuestionType {
-  TypeId   Int        @id(map: "PK__Question__516F03B528DDA595") @default(autoincrement())
-  TypeName String     @unique(map: "UQ__Question__D4E7DFA88542C69A") @db.NVarChar(100)
+  TypeId   Int        @id(map: "PK__Question__516F03B59709F13F") @default(autoincrement())
+  TypeName String     @unique(map: "UQ__Question__D4E7DFA88B9A9A92") @db.NVarChar(100)
   Question Question[]
 }
 
 model Quiz {
-  QuizId          Int               @id(map: "PK__Quiz__8B42AE8E4064B634") @default(autoincrement())
+  QuizId          Int               @id(map: "PK__Quiz__8B42AE8E16E608FF") @default(autoincrement())
   Title           String            @db.NVarChar(100)
   SkillId         Int?
   Description     String?           @db.NVarChar(500)
@@ -276,7 +277,7 @@ model Quiz {
 }
 
 model QuizPart {
-  PartId       Int            @id(map: "PK__QuizPart__7C3F0D507CB07AF0") @default(autoincrement())
+  PartId       Int            @id(map: "PK__QuizPart__7C3F0D50C921AD74") @default(autoincrement())
   QuizId       Int
   PartTitle    String         @db.NVarChar(100)
   SortOrder    Int
@@ -293,19 +294,19 @@ model QuizQuestion {
   Question   Question @relation(fields: [QuestionId], references: [QuestionId], onUpdate: NoAction, map: "FK_QuizQuestion_Question")
   Quiz       Quiz     @relation(fields: [QuizId], references: [QuizId], onDelete: Cascade, onUpdate: NoAction, map: "FK_QuizQuestion_Quiz")
 
-  @@id([QuizId, QuestionId], map: "PK__QuizQues__5B9EA8740AC1684A")
+  @@id([QuizId, QuestionId], map: "PK__QuizQues__5B9EA874E3960612")
 }
 
 model QuizSkill {
-  SkillId          Int               @id(map: "PK__QuizSkil__DFA09187F7054491") @default(autoincrement())
+  SkillId          Int               @id(map: "PK__QuizSkil__DFA09187F0435AA9") @default(autoincrement())
   SkillDescription String            @db.NVarChar(100)
   MockTestSection  MockTestSection[]
   Quiz             Quiz[]
 }
 
 model Role {
-  RoleId         Int              @id(map: "PK__Role__8AFACE1A362323AC") @default(autoincrement())
-  RoleName       String           @unique(map: "UQ__Role__8A2B616011E015E9") @db.NVarChar(100)
+  RoleId         Int              @id(map: "PK__Role__8AFACE1A3E24E5B4") @default(autoincrement())
+  RoleName       String           @unique(map: "UQ__Role__8A2B61605A777898") @db.NVarChar(100)
   AppUser        AppUser[]
   RolePermission RolePermission[]
 }
@@ -321,7 +322,7 @@ model RolePermission {
 }
 
 model UserActivity {
-  ActivityId   Int      @id(map: "PK__UserActi__45F4A7918E0F87CE") @default(autoincrement())
+  ActivityId   Int      @id(map: "PK__UserActi__45F4A7918E44633F") @default(autoincrement())
   UserId       Int
   ActivityType String   @db.NVarChar(50)
   TargetId     Int?
@@ -331,7 +332,7 @@ model UserActivity {
 }
 
 model UserAnswer {
-  UserAnswerId    Int              @id(map: "PK__UserAnsw__47CE237FAF78D019") @default(autoincrement())
+  UserAnswerId    Int              @id(map: "PK__UserAnsw__47CE237FCC8BCC5B") @default(autoincrement())
   AttemptId       Int
   QuestionId      Int
   AnswerText      String?          @db.NVarChar(1024)
@@ -342,7 +343,7 @@ model UserAnswer {
 }
 
 model UserAttempt {
-  AttemptId     Int          @id(map: "PK__UserAtte__891A68E65CB84ACE") @default(autoincrement())
+  AttemptId     Int          @id(map: "PK__UserAtte__891A68E653F97323") @default(autoincrement())
   UserId        Int
   QuizId        Int
   StartTime     DateTime     @default(dbgenerated("sysdatetime()"), map: "DF__UserAttem__Start__00200768")
@@ -355,7 +356,7 @@ model UserAttempt {
 }
 
 model UserEssayAnswer {
-  UserAnswerId      Int                 @id(map: "PK__UserEssa__47CE237F8087B625")
+  UserAnswerId      Int                 @id(map: "PK__UserEssa__47CE237F4520BFF9")
   EssayText         String              @db.NVarChar(Max)
   Mark              Decimal?            @db.Decimal(5, 2)
   TeacherFeedback   String?             @db.NVarChar(Max)
@@ -369,7 +370,7 @@ model UserFavorite {
   Quiz    Quiz    @relation(fields: [QuizId], references: [QuizId], onDelete: Cascade, onUpdate: NoAction, map: "FK_UserFavorite_Quiz")
   AppUser AppUser @relation(fields: [UserId], references: [UserId], onDelete: Cascade, onUpdate: NoAction, map: "FK_UserFavorite_User")
 
-  @@id([UserId, QuizId], map: "PK__UserFavo__EF3CE6A4E724E068")
+  @@id([UserId, QuizId], map: "PK__UserFavo__EF3CE6A47A9703FE")
 }
 
 model UserLexiconProgress {
@@ -393,11 +394,11 @@ model UserRating {
   Quiz        Quiz    @relation(fields: [QuizId], references: [QuizId], onDelete: Cascade, onUpdate: NoAction, map: "FK_UserRating_Quiz")
   AppUser     AppUser @relation(fields: [UserId], references: [UserId], onDelete: Cascade, onUpdate: NoAction, map: "FK_UserRating_User")
 
-  @@id([UserId, QuizId], map: "PK__UserRati__EF3CE6A4A476B73C")
+  @@id([UserId, QuizId], map: "PK__UserRati__EF3CE6A4BF433B45")
 }
 
 model WritingAssessment {
-  AssessmentId             Int             @id(map: "PK__WritingA__3D2BF81E7A58B24A") @default(autoincrement())
+  AssessmentId             Int             @id(map: "PK__WritingA__3D2BF81EE7C939E0") @default(autoincrement())
   UserEssayAnswerId        Int
   TaskResponseScore        Decimal?        @db.Decimal(5, 2)
   CoherenceCohesionScore   Decimal?        @db.Decimal(5, 2)

--- a/server/api/controllers/lexicon.ts
+++ b/server/api/controllers/lexicon.ts
@@ -5,11 +5,16 @@ import LexiconGroupModel from "../../models/lexicon/LexiconGroupModel";
 import UserLexiconProgressModel from "../../models/lexicon/UserLexiconProgressModel";
 
 export default {
-  getWords: async (type, limit) => {
+  getWords: async (type, limit, synAnt?: boolean) => {
     try {
-      const words = limit
-        ? await LexiconModel.findRandom(limit, type)
-        : await LexiconModel.findAll(type);
+      let words;
+      if (synAnt) {
+        words = await LexiconModel.findRandomWithSynAnt(limit ?? 50);
+      } else {
+        words = limit
+          ? await LexiconModel.findRandom(limit, type)
+          : await LexiconModel.findAll(type);
+      }
       const formatted = words.map((w) => {
         // normalize results when using raw queries
         const typeName = w.LexiconType

--- a/server/api/routes/lexicon.ts
+++ b/server/api/routes/lexicon.ts
@@ -5,9 +5,17 @@ import authMiddleware from "../middlewares/auth";
 const router = express.Router();
 
 router.get("/words", async (req, res) => {
-  const { type, limit } = req.query as { type?: string; limit?: string };
+  const { type, limit, synAnt } = req.query as {
+    type?: string;
+    limit?: string;
+    synAnt?: string;
+  };
   const parsedLimit = limit ? Number(limit) : undefined;
-  const result = await lexiconController.getWords(type, parsedLimit);
+  const result = await lexiconController.getWords(
+    type,
+    parsedLimit,
+    synAnt === "true"
+  );
   res.json(result);
 });
 

--- a/server/models/lexicon/LexiconModel.ts
+++ b/server/models/lexicon/LexiconModel.ts
@@ -54,5 +54,19 @@ export class LexiconModel {
       LexiconType: { TypeId: r.TypeId, TypeName: r.TypeName },
     }));
   }
+
+  static async findRandomWithSynAnt(limit: number) {
+    const query = `SELECT TOP (${limit}) l.*, lt.TypeName
+      FROM Lexicon l
+      JOIN LexiconType lt ON l.TypeId = lt.TypeId
+      WHERE (l.Synonyms IS NOT NULL AND LTRIM(RTRIM(l.Synonyms)) <> '')
+         OR (l.Antonyms IS NOT NULL AND LTRIM(RTRIM(l.Antonyms)) <> '')
+      ORDER BY NEWID()`;
+    const rows: any[] = await prisma.$queryRawUnsafe(query);
+    return rows.map((r) => ({
+      ...r,
+      LexiconType: { TypeId: r.TypeId, TypeName: r.TypeName },
+    }));
+  }
 }
 export default LexiconModel;

--- a/server/models/lexicon/LexiconModel.ts
+++ b/server/models/lexicon/LexiconModel.ts
@@ -60,7 +60,7 @@ export class LexiconModel {
       FROM Lexicon l
       JOIN LexiconType lt ON l.TypeId = lt.TypeId
       WHERE (l.Synonyms IS NOT NULL AND LTRIM(RTRIM(l.Synonyms)) <> '')
-         OR (l.Antonyms IS NOT NULL AND LTRIM(RTRIM(l.Antonyms)) <> '')
+        AND (l.Antonyms IS NOT NULL AND LTRIM(RTRIM(l.Antonyms)) <> '')
       ORDER BY NEWID()`;
     const rows: any[] = await prisma.$queryRawUnsafe(query);
     return rows.map((r) => ({

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -456,7 +456,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
               <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-6 items-stretch">
                 {currentRound.allOptions.map((option, index) => (
                   <motion.div
-                    key={option}
+                    key={`${option}-${index}`}
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: index * 0.05 }}

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -24,6 +24,7 @@ interface WordItem {
   text: string;
   meaning?: string;
   synonyms?: string | null;
+  antonyms?: string | null;
   related?: string | null;
   guideword?: string | null;
 }
@@ -40,6 +41,7 @@ interface GameRound {
   targetWord: string;
   targetMeaning?: string;
   synonyms?: string[];
+  antonyms?: string[];
   guidewords?: string[];
   relatedWords: string[];
   distractors: string[];
@@ -71,42 +73,78 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
   const [wordGroups, setWordGroups] = useState<WordGroup[]>([]);
   const [noWordsAvailable, setNoWordsAvailable] = useState(false);
-  const [mode, setMode] = useState<'vocabulary' | 'idiom' | 'phrasal verb'>('vocabulary');
+  const [mode, setMode] = useState<'vocabulary' | 'idiom' | 'phrasal verb' | 'syn-ant'>('vocabulary');
   const API_URL = import.meta.env.VITE_SERVER_ENDPOINT;
 
   useEffect(() => {
-    const type = mode;
-    fetch(`${API_URL}lexicon/groups?type=${type}&limit=50`)
-      .then(res => res.json())
-      .then(data => {
-        if (data.response) {
-          const groups = data.response
-            .map((g: any) => ({
-              ...g,
-              words: g.words.map((w: any) =>
-                typeof w === 'string'
-                  ? { text: w }
-                  : {
-                      text: w.expression,
-                      meaning: w.meaning,
-                      synonyms: w.synonyms,
-                      related: w.related,
-                      guideword: w.guideword,
-                    }
-              ),
-            }))
-            .filter((g: any) => g.words.length > 0);
-          setWordGroups(groups);
-          setNoWordsAvailable(groups.length === 0);
-        } else {
+    if (mode === 'syn-ant') {
+      fetch(`${API_URL}lexicon/words?limit=200`)
+        .then(res => res.json())
+        .then(data => {
+          if (data.response) {
+            const words = data.response
+              .filter((w: any) => w.Synonyms && w.Antonyms)
+              .map((w: any) => ({
+                text: w.Word,
+                meaning: w.Definition,
+                synonyms: w.Synonyms,
+                antonyms: w.Antonyms,
+                guideword: w.Guideword,
+                related: w.RelatedLexicon,
+              }));
+            setWordGroups([
+              {
+                id: 'syn-ant',
+                theme: 'Synonyms & Antonyms',
+                words,
+                description: '',
+              },
+            ]);
+            setNoWordsAvailable(words.length === 0);
+          } else {
+            setWordGroups([]);
+            setNoWordsAvailable(true);
+          }
+        })
+        .catch(() => {
           setWordGroups([]);
           setNoWordsAvailable(true);
-        }
-      })
-      .catch(() => {
-        setWordGroups([]);
-        setNoWordsAvailable(true);
-      });
+        });
+    } else {
+      const type = mode;
+      fetch(`${API_URL}lexicon/groups?type=${type}&limit=50`)
+        .then(res => res.json())
+        .then(data => {
+          if (data.response) {
+            const groups = data.response
+              .map((g: any) => ({
+                ...g,
+                words: g.words.map((w: any) =>
+                  typeof w === 'string'
+                    ? { text: w }
+                    : {
+                        text: w.expression,
+                        meaning: w.meaning,
+                        synonyms: w.synonyms,
+                        antonyms: w.antonyms,
+                        related: w.related,
+                        guideword: w.guideword,
+                      }
+                ),
+              }))
+              .filter((g: any) => g.words.length > 0);
+            setWordGroups(groups);
+            setNoWordsAvailable(groups.length === 0);
+          } else {
+            setWordGroups([]);
+            setNoWordsAvailable(true);
+          }
+        })
+        .catch(() => {
+          setWordGroups([]);
+          setNoWordsAvailable(true);
+        });
+    }
   }, [API_URL, mode]);
 
   // Distractor words fetched from the database
@@ -147,6 +185,98 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   }, [isGameActive, isPaused, isGameComplete, timeLeft]);
 
   // Generate a new round
+  const parseList = (val?: string | null) =>
+    val ? val.split(',').map((s) => s.trim()).filter(Boolean) : [];
+
+  const buildVocabularyRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
+    const targetWord = item.text;
+    const synonyms = parseList(item.synonyms);
+    const related = parseList(item.related);
+    const guidewords = parseList(item.guideword);
+
+    let relatedSet = Array.from(new Set([...synonyms, ...related]));
+    if (relatedSet.length === 0) {
+      relatedSet = group.words.filter(w => w.text !== targetWord).map(w => w.text);
+    }
+
+    const relatedWords = relatedSet
+      .filter(w => w.toLowerCase() !== targetWord.toLowerCase())
+      .sort(() => Math.random() - 0.5)
+      .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+
+    const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+    const selectedDistractors = distractorWords
+      .filter(w => w !== targetWord && !relatedSet.includes(w))
+      .sort(() => Math.random() - 0.5)
+      .slice(0, numDistractors);
+
+    const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+    return {
+      id: `round-${roundNum}`,
+      targetWord,
+      targetMeaning: item.meaning,
+      synonyms,
+      guidewords,
+      relatedWords,
+      distractors: selectedDistractors,
+      allOptions,
+      theme: group.theme,
+    };
+  };
+
+  const buildMeaningRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
+    const targetWord = item.text;
+    const targetMeaning = item.meaning as string;
+    const totalOptions = difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
+    const allMeanings = wordGroups.flatMap(g => g.words.map(w => w.meaning).filter(Boolean));
+    const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
+    const selectedDistractors = availableDistractors
+      .sort(() => Math.random() - 0.5)
+      .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
+    const allOptions = [targetMeaning, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+    return {
+      id: `round-${roundNum}`,
+      targetWord,
+      targetMeaning,
+      relatedWords: [targetMeaning],
+      distractors: selectedDistractors,
+      allOptions,
+      theme: group.theme,
+    };
+  };
+
+  const buildSynAntRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
+    const targetWord = item.text;
+    const synonyms = parseList(item.synonyms);
+    const antonyms = parseList(item.antonyms);
+    const relatedSet = [...synonyms, ...antonyms];
+    const relatedWords = relatedSet
+      .sort(() => Math.random() - 0.5)
+      .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+
+    const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+    const exclude = [targetWord, ...relatedSet];
+    const selectedDistractors = distractorWords
+      .filter(w => !exclude.some(ex => w.toLowerCase().includes(ex.toLowerCase())))
+      .sort(() => Math.random() - 0.5)
+      .slice(0, numDistractors);
+    const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+    return {
+      id: `round-${roundNum}`,
+      targetWord,
+      targetMeaning: item.meaning,
+      synonyms,
+      antonyms,
+      relatedWords,
+      distractors: selectedDistractors,
+      allOptions,
+      theme: group.theme,
+    };
+  };
+
   const generateRound = (roundNum: number = roundNumber) => {
     const validGroups = wordGroups.filter(g => g.words.length > 0);
     if (validGroups.length === 0) {
@@ -158,76 +288,16 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     const randomGroup = validGroups[Math.floor(Math.random() * validGroups.length)];
     const randomItem = randomGroup.words[Math.floor(Math.random() * randomGroup.words.length)];
 
+    let newRound: GameRound;
     if (mode === 'vocabulary') {
-      const targetWord = randomItem.text;
-
-      const parseList = (val?: string | null) =>
-        val ? val.split(',').map((s) => s.trim()).filter(Boolean) : [];
-
-      const synonyms = parseList(randomItem.synonyms);
-      const related = parseList(randomItem.related);
-      const guidewords = parseList(randomItem.guideword);
-
-      let relatedSet = Array.from(new Set([...synonyms, ...related]));
-      if (relatedSet.length === 0) {
-        relatedSet = randomGroup.words
-          .filter((w) => w.text !== targetWord)
-          .map((w) => w.text);
-      }
-
-      const relatedWords = relatedSet
-        .filter((w) => w.toLowerCase() !== targetWord.toLowerCase())
-        .sort(() => Math.random() - 0.5)
-        .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
-
-      const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
-      const selectedDistractors = distractorWords
-        .filter((w) => w !== targetWord && !relatedSet.includes(w))
-        .sort(() => Math.random() - 0.5)
-        .slice(0, numDistractors);
-
-      const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
-
-      const newRound: GameRound = {
-        id: `round-${roundNum}`,
-        targetWord,
-        targetMeaning: randomItem.meaning,
-        synonyms,
-        guidewords,
-        relatedWords,
-        distractors: selectedDistractors,
-        allOptions,
-        theme: randomGroup.theme,
-      };
-
-      setCurrentRound(newRound);
+      newRound = buildVocabularyRound(randomGroup, randomItem, roundNum);
+    } else if (mode === 'syn-ant') {
+      newRound = buildSynAntRound(randomGroup, randomItem, roundNum);
     } else {
-      const allMeanings = wordGroups.flatMap(g => g.words.map(w => w.meaning).filter(Boolean));
-      const targetWord = randomItem.text;
-      const targetMeaning = randomItem.meaning as string;
-      const totalOptions = difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
-      const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
-      const selectedDistractors = availableDistractors
-        .sort(() => Math.random() - 0.5)
-        .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
-
-      const allOptions = [targetMeaning, ...selectedDistractors].sort(
-        () => Math.random() - 0.5
-      );
-
-      const newRound: GameRound = {
-        id: `round-${roundNum}`,
-        targetWord,
-        targetMeaning,
-        relatedWords: [targetMeaning],
-        distractors: selectedDistractors,
-        allOptions,
-        theme: randomGroup.theme,
-      };
-
-      setCurrentRound(newRound);
+      newRound = buildMeaningRound(randomGroup, randomItem, roundNum);
     }
 
+    setCurrentRound(newRound);
     setSelectedWords([]);
     setFeedback(null);
     setTimeLeft(difficulty === 'easy' ? 45 : difficulty === 'medium' ? 30 : 20);
@@ -366,7 +436,9 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
               ? 'Find words related to the target word. Test your vocabulary knowledge and word connections!'
               : mode === 'idiom'
               ? 'Select the correct meaning for the displayed idiom.'
-              : 'Select the correct meaning for the displayed phrasal verb.'}
+              : mode === 'phrasal verb'
+              ? 'Select the correct meaning for the displayed phrasal verb.'
+              : 'Choose words that are synonyms or antonyms of the target word.'}
           </p>
         </div>
 
@@ -374,7 +446,8 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
           {[
             { id: 'vocabulary', label: 'Vocabulary' },
             { id: 'idiom', label: 'Idioms' },
-            { id: 'phrasal verb', label: 'Phrasal Verbs' }
+            { id: 'phrasal verb', label: 'Phrasal Verbs' },
+            { id: 'syn-ant', label: 'Synonyms & Antonyms' }
           ].map(m => (
             <Button
               key={m.id}
@@ -582,7 +655,11 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
             <CardHeader>
               <div className="text-center">
                 <CardTitle className="text-2xl mb-2">
-                  {mode === 'vocabulary' ? 'Find words related to:' : 'What is the meaning of:'}
+                  {mode === 'vocabulary'
+                    ? 'Find words related to:'
+                    : mode === 'syn-ant'
+                    ? 'Select synonyms or antonyms for:'
+                    : 'What is the meaning of:'}
                 </CardTitle>
                 <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-2">
                   {currentRound.targetWord.toUpperCase()}
@@ -604,10 +681,12 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                   <span className="text-sm text-gray-600 dark:text-gray-400">
                     {mode === 'vocabulary'
                       ? `Select ${Math.max(1, currentRound.relatedWords.length)} related word${Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}`
+                      : mode === 'syn-ant'
+                      ? `Select ${Math.max(1, currentRound.relatedWords.length)} correct word${Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}`
                       : 'Select the correct meaning'}
                   </span>
                 </div>
-                {mode === 'vocabulary' && (
+                {(mode === 'vocabulary' || mode === 'syn-ant') && (
                   <div className="text-xs text-gray-500">
                     Selected: {selectedWords.length} / {Math.max(1, currentRound.relatedWords.length)}
                   </div>
@@ -712,6 +791,11 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                         {currentRound.synonyms && currentRound.synonyms.length > 0 && (
                           <p className="mt-2">
                             <strong>Synonyms:</strong> {currentRound.synonyms.join(', ')}
+                          </p>
+                        )}
+                        {currentRound.antonyms && currentRound.antonyms.length > 0 && (
+                          <p className="mt-2">
+                            <strong>Antonyms:</strong> {currentRound.antonyms.join(', ')}
                           </p>
                         )}
                         {currentRound.guidewords && currentRound.guidewords.length > 0 && (

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -335,7 +335,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     if (correctCount === currentRound.relatedWords.length && incorrectCount === 0) {
       message = `Perfect! +${totalRoundScore} points`;
       setGameStats(prev => ({ ...prev, correctAnswers: prev.correctAnswers + 1 }));
-    } else if (correctCount > 0 || incorrectCount > 0) {
+    } else if (correctCount > 0) {
       message = `Partially correct. +${totalRoundScore} points`;
     } else {
       message = `Better luck next time. +${totalRoundScore} points`;

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -131,7 +131,10 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
   // Generate a new round
 
-  const generateRound = (roundNum: number = roundNumber) => {
+  const generateRound = (
+    roundNum: number = roundNumber,
+    diff: 'easy' | 'medium' | 'hard' = difficulty
+  ) => {
     const filteredGroups = wordGroups
       .map(g => ({
         ...g,
@@ -159,7 +162,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
         randomItem,
         roundNum,
         distractorWords,
-        difficulty
+        diff
       );
     } else if (mode === 'syn-ant') {
       newRound = buildSynAntRound(
@@ -167,7 +170,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
         randomItem,
         roundNum,
         distractorWords,
-        difficulty
+        diff
       );
     } else {
       const allMeanings = wordGroups
@@ -177,7 +180,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
           randomGroup,
           randomItem,
           roundNum,
-          difficulty,
+          diff,
           allMeanings
         );
       } else {
@@ -185,7 +188,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
           randomGroup,
           randomItem,
           roundNum,
-          difficulty,
+          diff,
           allMeanings
         );
       }
@@ -195,7 +198,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     setUsedWords(prev => [...prev, randomItem.text]);
     setSelectedWords([]);
     setFeedback(null);
-    setTimeLeft(difficulty === 'easy' ? 45 : difficulty === 'medium' ? 30 : 20);
+    setTimeLeft(diff === 'easy' ? 45 : diff === 'medium' ? 30 : 20);
   };
 
   // Start game
@@ -214,7 +217,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     setScore(0);
     setGameStats({ correctAnswers: 0, totalTime: 0, accuracy: 0 });
     setUsedWords([]);
-    generateRound(1);
+    generateRound(1, selectedDifficulty);
   };
 
   // Handle word selection

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -4,6 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
+import SetupScreen from './word-association/SetupScreen';
+import CompletionScreen from './word-association/CompletionScreen';
+import PauseOverlay from './word-association/PauseOverlay';
+import FeedbackModal from './word-association/FeedbackModal';
+import type { WordGroup, WordItem, GameRound, GameMode, RelationType } from './word-association/types';
 import { 
   Brain, 
   Clock, 
@@ -19,35 +24,6 @@ import {
   Lightbulb,
   Zap
 } from 'lucide-react';
-
-interface WordItem {
-  text: string;
-  meaning?: string;
-  synonyms?: string | null;
-  antonyms?: string | null;
-  related?: string | null;
-  guideword?: string | null;
-}
-
-interface WordGroup {
-  id: string;
-  theme: string;
-  words: WordItem[];
-  description: string;
-}
-
-interface GameRound {
-  id: string;
-  targetWord: string;
-  targetMeaning?: string;
-  synonyms?: string[];
-  antonyms?: string[];
-  guidewords?: string[];
-  relatedWords: string[];
-  distractors: string[];
-  allOptions: string[];
-  theme: string;
-}
 
 interface WordAssociationGameProps {
   onBack: () => void;
@@ -73,7 +49,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
   const [wordGroups, setWordGroups] = useState<WordGroup[]>([]);
   const [noWordsAvailable, setNoWordsAvailable] = useState(false);
-  const [mode, setMode] = useState<'vocabulary' | 'idiom' | 'phrasal verb' | 'syn-ant'>('vocabulary');
+  const [mode, setMode] = useState<GameMode>('vocabulary');
   const API_URL = import.meta.env.VITE_SERVER_ENDPOINT;
 
   useEffect(() => {
@@ -251,13 +227,17 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     const targetWord = item.text;
     const synonyms = parseList(item.synonyms);
     const antonyms = parseList(item.antonyms);
-    const relatedSet = [...synonyms, ...antonyms];
+    const useSynonyms = Math.random() < 0.5;
+    const relationType: RelationType = useSynonyms ? 'synonym' : 'antonym';
+    const relatedSet = useSynonyms ? synonyms : antonyms;
+    const allRelated = [...synonyms, ...antonyms];
+
     const relatedWords = relatedSet
       .sort(() => Math.random() - 0.5)
       .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
 
     const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
-    const exclude = [targetWord, ...relatedSet];
+    const exclude = [targetWord, ...allRelated];
     const selectedDistractors = distractorWords
       .filter(w => !exclude.some(ex => w.toLowerCase().includes(ex.toLowerCase())))
       .sort(() => Math.random() - 0.5)
@@ -274,6 +254,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
       distractors: selectedDistractors,
       allOptions,
       theme: group.theme,
+      relationType,
     };
   };
 
@@ -423,160 +404,28 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   // Game setup screen
   if (!isGameActive && !isGameComplete) {
     return (
-      <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8">
-          <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Brain className="w-10 h-10 text-white" />
-          </div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-            Word Association Game
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400">
-            {mode === 'vocabulary'
-              ? 'Find words related to the target word. Test your vocabulary knowledge and word connections!'
-              : mode === 'idiom'
-              ? 'Select the correct meaning for the displayed idiom.'
-              : mode === 'phrasal verb'
-              ? 'Select the correct meaning for the displayed phrasal verb.'
-              : 'Choose words that are synonyms or antonyms of the target word.'}
-          </p>
-        </div>
-
-        <div className="flex justify-center gap-2 mb-6">
-          {[
-            { id: 'vocabulary', label: 'Vocabulary' },
-            { id: 'idiom', label: 'Idioms' },
-            { id: 'phrasal verb', label: 'Phrasal Verbs' },
-            { id: 'syn-ant', label: 'Synonyms & Antonyms' }
-          ].map(m => (
-            <Button
-              key={m.id}
-              variant={mode === m.id ? 'default' : 'outline'}
-              onClick={() => setMode(m.id as any)}
-            >
-              {m.label}
-            </Button>
-          ))}
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-4 mb-8">
-          {(['easy', 'medium', 'hard'] as const).map((level) => (
-            <Card
-              key={level}
-              className="cursor-pointer hover:shadow-lg transition-all duration-300 hover:scale-105"
-              onClick={() => startGame(level)}
-            >
-              <CardContent className="p-6 text-center">
-                <div className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 ${
-                  level === 'easy' ? 'bg-green-100 dark:bg-green-900/20' :
-                  level === 'medium' ? 'bg-yellow-100 dark:bg-yellow-900/20' :
-                  'bg-red-100 dark:bg-red-900/20'
-                }`}>
-                  <Brain className={`w-6 h-6 ${
-                    level === 'easy' ? 'text-green-600 dark:text-green-400' :
-                    level === 'medium' ? 'text-yellow-600 dark:text-yellow-400' :
-                    'text-red-600 dark:text-red-400'
-                  }`} />
-                </div>
-                <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-2 capitalize">
-                  {level}
-                </h3>
-                <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                  {level === 'easy' && '45s per round • 7 words to choose from'}
-                  {level === 'medium' && '30s per round • 10 words to choose from'}
-                  {level === 'hard' && '20s per round • 13 words to choose from'}
-                </div>
-                <Button className="w-full" disabled={noWordsAvailable}>
-                  <Play className="w-4 h-4 mr-2" />
-                  Start Game
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-          {noWordsAvailable && (
-            <div className="col-span-full text-center text-gray-500 dark:text-gray-400">
-              No words available for this mode.
-            </div>
-          )}
-        </div>
-
-        <div className="text-center">
-          <Button variant="outline" onClick={onBack}>
-            <Home className="w-4 h-4 mr-2" />
-            Back to Games
-          </Button>
-        </div>
-      </div>
+      <SetupScreen
+        mode={mode}
+        setMode={setMode}
+        startGame={startGame}
+        noWordsAvailable={noWordsAvailable}
+        onBack={onBack}
+      />
     );
   }
 
   // Game completion screen
   if (isGameComplete) {
     return (
-      <div className="max-w-2xl mx-auto text-center">
-        <motion.div
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
-          transition={{ duration: 0.5 }}
-        >
-          <Trophy className="w-20 h-20 text-yellow-500 mx-auto mb-6" />
-        </motion.div>
-        
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-          Game Complete! 🧠
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-8">
-          You've completed all {totalRounds} rounds of word association!
-        </p>
-
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
-                {score}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Total Score</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-green-600 dark:text-green-400">
-                {Math.round(gameStats.accuracy)}%
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Accuracy</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                {gameStats.correctAnswers}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Perfect Rounds</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <div className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-                {Math.floor(gameStats.totalTime / 60)}:{(gameStats.totalTime % 60).toString().padStart(2, '0')}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Time Played</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-4">
-          <div className="flex gap-4 justify-center">
-            <Button onClick={resetGame} size="lg">
-              <RotateCcw className="w-4 h-4 mr-2" />
-              Play Again
-            </Button>
-            <Button variant="outline" onClick={onBack} size="lg">
-              <Home className="w-4 h-4 mr-2" />
-              Back to Games
-            </Button>
-          </div>
-        </div>
-      </div>
+      <CompletionScreen
+        totalRounds={totalRounds}
+        score={score}
+        accuracy={gameStats.accuracy}
+        correctAnswers={gameStats.correctAnswers}
+        totalTime={gameStats.totalTime}
+        resetGame={resetGame}
+        onBack={onBack}
+      />
     );
   }
 
@@ -624,29 +473,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
       </div>
 
       {/* Pause Overlay */}
-      <AnimatePresence>
-        {isPaused && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-          >
-            <Card>
-              <CardContent className="p-8 text-center">
-                <Pause className="w-12 h-24 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
-                  Game Paused
-                </h3>
-                <Button onClick={togglePause}>
-                  <Play className="w-4 h-4 mr-2" />
-                  Resume Game
-                </Button>
-              </CardContent>
-            </Card>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <PauseOverlay isPaused={isPaused} togglePause={togglePause} />
 
       {currentRound && (
         <>
@@ -658,7 +485,9 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                   {mode === 'vocabulary'
                     ? 'Find words related to:'
                     : mode === 'syn-ant'
-                    ? 'Select synonyms or antonyms for:'
+                    ? (
+                        <>Select <span className={`font-bold ${currentRound.relationType === 'synonym' ? 'text-green-600' : 'text-red-600'}`}>{currentRound.relationType === 'synonym' ? 'synonyms' : 'antonyms'}</span> for:</>
+                      )
                     : 'What is the meaning of:'}
                 </CardTitle>
                 <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-2">
@@ -682,7 +511,9 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
                     {mode === 'vocabulary'
                       ? `Select ${Math.max(1, currentRound.relatedWords.length)} related word${Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}`
                       : mode === 'syn-ant'
-                      ? `Select ${Math.max(1, currentRound.relatedWords.length)} correct word${Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}`
+                      ? (
+                          <>Select {Math.max(1, currentRound.relatedWords.length)} <span className={`font-bold ${currentRound.relationType === 'synonym' ? 'text-green-600' : 'text-red-600'}`}>{currentRound.relationType === 'synonym' ? 'synonym' : 'antonym'}{Math.max(1, currentRound.relatedWords.length) > 1 ? 's' : ''}</span></>
+                        )
                       : 'Select the correct meaning'}
                   </span>
                 </div>
@@ -734,82 +565,12 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
           </Card>
 
           {/* Feedback */}
-          <AnimatePresence>
-            {feedback && (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-                onClick={closeFeedback}
-              >
-                <Card onClick={e => e.stopPropagation()}>
-                  <CardContent className="p-8 text-center">
-                    <div className="mb-4">
-                      {feedback.includes('Perfect') && (
-                        <Trophy className="w-12 h-12 text-yellow-500 mx-auto" />
-                      )}
-                      {feedback.includes('Partially') && (
-                        <CheckCircle className="w-12 h-12 text-green-500 mx-auto" />
-                      )}
-                      {feedback.includes('Better luck') && (
-                        <XCircle className="w-12 h-12 text-red-500 mx-auto" />
-                      )}
-                      {feedback.includes("Time's up") && (
-                        <Clock className="w-12 h-12 text-orange-500 mx-auto" />
-                      )}
-                    </div>
-                    <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-                      {feedback}
-                    </h3>
-                    {currentRound && (
-                      <div className="text-sm text-gray-600 dark:text-gray-400">
-                        <p className="mb-2">Correct answers were:</p>
-                        <div className="flex flex-wrap gap-1 justify-center">
-                          {currentRound.relatedWords.map(word => (
-                            <Badge key={word} variant="success">
-                              {word}
-                            </Badge>
-                          ))}
-                        </div>
-                        <p className="mt-4 mb-2">Your selections:</p>
-                        <div className="flex flex-wrap gap-1 justify-center">
-                          {selectedWords.map(word => (
-                            <Badge
-                              key={word}
-                              variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}
-                            >
-                              {word}
-                            </Badge>
-                          ))}
-                        </div>
-                        {currentRound.targetMeaning && (
-                          <p className="mt-4">
-                            <strong>Definition:</strong> {currentRound.targetMeaning}
-                          </p>
-                        )}
-                        {currentRound.synonyms && currentRound.synonyms.length > 0 && (
-                          <p className="mt-2">
-                            <strong>Synonyms:</strong> {currentRound.synonyms.join(', ')}
-                          </p>
-                        )}
-                        {currentRound.antonyms && currentRound.antonyms.length > 0 && (
-                          <p className="mt-2">
-                            <strong>Antonyms:</strong> {currentRound.antonyms.join(', ')}
-                          </p>
-                        )}
-                        {currentRound.guidewords && currentRound.guidewords.length > 0 && (
-                          <p className="mt-2">
-                            <strong>Guideword:</strong> {currentRound.guidewords.join(', ')}
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <FeedbackModal
+            feedback={feedback}
+            currentRound={currentRound}
+            selectedWords={selectedWords}
+            closeFeedback={closeFeedback}
+          />
         </>
       )}
     </div>

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
@@ -8,7 +8,23 @@ import SetupScreen from './word-association/SetupScreen';
 import CompletionScreen from './word-association/CompletionScreen';
 import PauseOverlay from './word-association/PauseOverlay';
 import FeedbackModal from './word-association/FeedbackModal';
-import type { WordGroup, WordItem, GameRound, GameMode, RelationType } from './word-association/types';
+import type { WordGroup, GameRound, GameMode } from './word-association/types';
+import {
+  fetchVocabularyGroups,
+  buildVocabularyRound,
+} from './word-association/modes/vocabulary';
+import {
+  fetchIdiomGroups,
+  buildIdiomRound,
+} from './word-association/modes/idiom';
+import {
+  fetchPhrasalVerbGroups,
+  buildPhrasalVerbRound,
+} from './word-association/modes/phrasalVerb';
+import {
+  fetchSynAntGroups,
+  buildSynAntRound,
+} from './word-association/modes/synAnt';
 import { 
   Brain, 
   Clock, 
@@ -54,74 +70,26 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   const API_URL = import.meta.env.VITE_SERVER_ENDPOINT;
 
   useEffect(() => {
-    if (mode === 'syn-ant') {
-      fetch(`${API_URL}lexicon/words?limit=200`)
-        .then(res => res.json())
-        .then(data => {
-          if (data.response) {
-            const words = data.response
-              .filter((w: any) => w.Synonyms && w.Antonyms)
-              .map((w: any) => ({
-                text: w.Word,
-                meaning: w.Definition,
-                synonyms: w.Synonyms,
-                antonyms: w.Antonyms,
-                guideword: w.Guideword,
-                related: w.RelatedLexicon,
-              }));
-            setWordGroups([
-              {
-                id: 'syn-ant',
-                theme: 'Synonyms & Antonyms',
-                words,
-                description: '',
-              },
-            ]);
-            setNoWordsAvailable(words.length === 0);
-          } else {
-            setWordGroups([]);
-            setNoWordsAvailable(true);
-          }
-        })
-        .catch(() => {
-          setWordGroups([]);
-          setNoWordsAvailable(true);
-        });
-    } else {
-      const type = mode;
-      fetch(`${API_URL}lexicon/groups?type=${type}&limit=50`)
-        .then(res => res.json())
-        .then(data => {
-          if (data.response) {
-            const groups = data.response
-              .map((g: any) => ({
-                ...g,
-                words: g.words.map((w: any) =>
-                  typeof w === 'string'
-                    ? { text: w }
-                    : {
-                        text: w.expression,
-                        meaning: w.meaning,
-                        synonyms: w.synonyms,
-                        antonyms: w.antonyms,
-                        related: w.related,
-                        guideword: w.guideword,
-                      }
-                ),
-              }))
-              .filter((g: any) => g.words.length > 0);
-            setWordGroups(groups);
-            setNoWordsAvailable(groups.length === 0);
-          } else {
-            setWordGroups([]);
-            setNoWordsAvailable(true);
-          }
-        })
-        .catch(() => {
-          setWordGroups([]);
-          setNoWordsAvailable(true);
-        });
-    }
+    const loadGroups = async () => {
+      try {
+        let groups: WordGroup[] = [];
+        if (mode === 'vocabulary') {
+          groups = await fetchVocabularyGroups(API_URL);
+        } else if (mode === 'idiom') {
+          groups = await fetchIdiomGroups(API_URL);
+        } else if (mode === 'phrasal verb') {
+          groups = await fetchPhrasalVerbGroups(API_URL);
+        } else {
+          groups = await fetchSynAntGroups(API_URL);
+        }
+        setWordGroups(groups);
+        setNoWordsAvailable(groups.length === 0);
+      } catch {
+        setWordGroups([]);
+        setNoWordsAvailable(true);
+      }
+    };
+    loadGroups();
   }, [API_URL, mode]);
 
   // Distractor words fetched from the database
@@ -162,102 +130,6 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   }, [isGameActive, isPaused, isGameComplete, timeLeft]);
 
   // Generate a new round
-  const parseList = (val?: string | null) =>
-    val ? val.split(',').map((s) => s.trim()).filter(Boolean) : [];
-
-  const buildVocabularyRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
-    const targetWord = item.text;
-    const synonyms = parseList(item.synonyms);
-    const related = parseList(item.related);
-    const guidewords = parseList(item.guideword);
-
-    let relatedSet = Array.from(new Set([...synonyms, ...related]));
-    if (relatedSet.length === 0) {
-      relatedSet = group.words.filter(w => w.text !== targetWord).map(w => w.text);
-    }
-
-    const relatedWords = relatedSet
-      .filter(w => w.toLowerCase() !== targetWord.toLowerCase())
-      .sort(() => Math.random() - 0.5)
-      .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
-
-    const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
-    const selectedDistractors = distractorWords
-      .filter(w => w !== targetWord && !relatedSet.includes(w))
-      .sort(() => Math.random() - 0.5)
-      .slice(0, numDistractors);
-
-    const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
-
-    return {
-      id: `round-${roundNum}`,
-      targetWord,
-      targetMeaning: item.meaning,
-      synonyms,
-      guidewords,
-      relatedWords,
-      distractors: selectedDistractors,
-      allOptions,
-      theme: group.theme,
-    };
-  };
-
-  const buildMeaningRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
-    const targetWord = item.text;
-    const targetMeaning = item.meaning as string;
-    const totalOptions = difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
-    const allMeanings = wordGroups.flatMap(g => g.words.map(w => w.meaning).filter(Boolean));
-    const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
-    const selectedDistractors = availableDistractors
-      .sort(() => Math.random() - 0.5)
-      .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
-    const allOptions = [targetMeaning, ...selectedDistractors].sort(() => Math.random() - 0.5);
-
-    return {
-      id: `round-${roundNum}`,
-      targetWord,
-      targetMeaning,
-      relatedWords: [targetMeaning],
-      distractors: selectedDistractors,
-      allOptions,
-      theme: group.theme,
-    };
-  };
-
-  const buildSynAntRound = (group: WordGroup, item: WordItem, roundNum: number): GameRound => {
-    const targetWord = item.text;
-    const synonyms = parseList(item.synonyms);
-    const antonyms = parseList(item.antonyms);
-    const useSynonyms = Math.random() < 0.5;
-    const relationType: RelationType = useSynonyms ? 'synonym' : 'antonym';
-    const relatedSet = useSynonyms ? synonyms : antonyms;
-    const allRelated = [...synonyms, ...antonyms];
-
-    const relatedWords = relatedSet
-      .sort(() => Math.random() - 0.5)
-      .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
-
-    const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
-    const exclude = [targetWord, ...allRelated];
-    const selectedDistractors = distractorWords
-      .filter(w => !exclude.some(ex => w.toLowerCase().includes(ex.toLowerCase())))
-      .sort(() => Math.random() - 0.5)
-      .slice(0, numDistractors);
-    const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
-
-    return {
-      id: `round-${roundNum}`,
-      targetWord,
-      targetMeaning: item.meaning,
-      synonyms,
-      antonyms,
-      relatedWords,
-      distractors: selectedDistractors,
-      allOptions,
-      theme: group.theme,
-      relationType,
-    };
-  };
 
   const generateRound = (roundNum: number = roundNumber) => {
     const filteredGroups = wordGroups
@@ -282,11 +154,41 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
 
     let newRound: GameRound;
     if (mode === 'vocabulary') {
-      newRound = buildVocabularyRound(randomGroup, randomItem, roundNum);
+      newRound = buildVocabularyRound(
+        randomGroup,
+        randomItem,
+        roundNum,
+        distractorWords,
+        difficulty
+      );
     } else if (mode === 'syn-ant') {
-      newRound = buildSynAntRound(randomGroup, randomItem, roundNum);
+      newRound = buildSynAntRound(
+        randomGroup,
+        randomItem,
+        roundNum,
+        distractorWords,
+        difficulty
+      );
     } else {
-      newRound = buildMeaningRound(randomGroup, randomItem, roundNum);
+      const allMeanings = wordGroups
+        .flatMap(g => g.words.map(w => w.meaning).filter(Boolean));
+      if (mode === 'idiom') {
+        newRound = buildIdiomRound(
+          randomGroup,
+          randomItem,
+          roundNum,
+          difficulty,
+          allMeanings
+        );
+      } else {
+        newRound = buildPhrasalVerbRound(
+          randomGroup,
+          randomItem,
+          roundNum,
+          difficulty,
+          allMeanings
+        );
+      }
     }
 
     setCurrentRound(newRound);

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -250,10 +250,10 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     if (correctCount === currentRound.relatedWords.length && incorrectCount === 0) {
       message = `Perfect! +${totalRoundScore} points`;
       setGameStats(prev => ({ ...prev, correctAnswers: prev.correctAnswers + 1 }));
-    } else if (correctCount > 0) {
-      message = `Partially correct. +${totalRoundScore} points`;
-    } else {
+    } else if (correctCount === 0) {
       message = `Better luck next time. +${totalRoundScore} points`;
+    } else {
+      message = `Partially correct. +${totalRoundScore} points`;
     }
 
     setFeedback(message);

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -50,6 +50,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   const [wordGroups, setWordGroups] = useState<WordGroup[]>([]);
   const [noWordsAvailable, setNoWordsAvailable] = useState(false);
   const [mode, setMode] = useState<GameMode>('vocabulary');
+  const [usedWords, setUsedWords] = useState<string[]>([]);
   const API_URL = import.meta.env.VITE_SERVER_ENDPOINT;
 
   useEffect(() => {
@@ -259,15 +260,25 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   };
 
   const generateRound = (roundNum: number = roundNumber) => {
-    const validGroups = wordGroups.filter(g => g.words.length > 0);
+    const filteredGroups = wordGroups
+      .map(g => ({
+        ...g,
+        words: g.words.filter(w => !usedWords.includes(w.text)),
+      }))
+      .filter(g => g.words.length > 0);
+
+    const validGroups = filteredGroups.length > 0 ? filteredGroups : wordGroups;
+
     if (validGroups.length === 0) {
       setIsGameActive(false);
       setNoWordsAvailable(true);
       return;
     }
 
-    const randomGroup = validGroups[Math.floor(Math.random() * validGroups.length)];
-    const randomItem = randomGroup.words[Math.floor(Math.random() * randomGroup.words.length)];
+    const randomGroup =
+      validGroups[Math.floor(Math.random() * validGroups.length)];
+    const randomItem =
+      randomGroup.words[Math.floor(Math.random() * randomGroup.words.length)];
 
     let newRound: GameRound;
     if (mode === 'vocabulary') {
@@ -279,6 +290,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     }
 
     setCurrentRound(newRound);
+    setUsedWords(prev => [...prev, randomItem.text]);
     setSelectedWords([]);
     setFeedback(null);
     setTimeLeft(difficulty === 'easy' ? 45 : difficulty === 'medium' ? 30 : 20);
@@ -299,6 +311,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     setRoundNumber(1);
     setScore(0);
     setGameStats({ correctAnswers: 0, totalTime: 0, accuracy: 0 });
+    setUsedWords([]);
     generateRound(1);
   };
 
@@ -376,6 +389,7 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
     setIsPaused(false);
     setGameStats({ correctAnswers: 0, totalTime: 0, accuracy: 0 });
     setFeedback(null);
+    setUsedWords([]);
   };
 
   // Toggle pause

--- a/src/components/WordAssociationGame.tsx
+++ b/src/components/WordAssociationGame.tsx
@@ -220,11 +220,23 @@ const WordAssociationGame: React.FC<WordAssociationGameProps> = ({ onBack }) => 
   // Handle word selection
   const handleWordSelect = (word: string) => {
     if (isPaused || !currentRound) return;
-    
-    if (selectedWords.includes(word)) {
-      setSelectedWords(prev => prev.filter(w => w !== word));
+
+    if (mode === 'idiom' || mode === 'phrasal verb') {
+      // Only one selection allowed for meaning based rounds
+      if (selectedWords.includes(word)) {
+        setSelectedWords([]);
+      } else {
+        setSelectedWords([word]);
+      }
     } else {
-      setSelectedWords(prev => [...prev, word]);
+      if (selectedWords.includes(word)) {
+        setSelectedWords(prev => prev.filter(w => w !== word));
+      } else {
+        const max = Math.max(1, currentRound.relatedWords.length);
+        if (selectedWords.length < max) {
+          setSelectedWords(prev => [...prev, word]);
+        }
+      }
     }
   };
 

--- a/src/components/word-association/CompletionScreen.tsx
+++ b/src/components/word-association/CompletionScreen.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent } from '../ui/card';
+import { Button } from '../ui/button';
+import { RotateCcw, Home, Trophy } from 'lucide-react';
+
+interface CompletionScreenProps {
+  totalRounds: number;
+  score: number;
+  accuracy: number;
+  correctAnswers: number;
+  totalTime: number;
+  resetGame: () => void;
+  onBack: () => void;
+}
+
+const CompletionScreen: React.FC<CompletionScreenProps> = ({
+  totalRounds,
+  score,
+  accuracy,
+  correctAnswers,
+  totalTime,
+  resetGame,
+  onBack,
+}) => {
+  return (
+    <div className="max-w-2xl mx-auto text-center">
+      <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ duration: 0.5 }}>
+        <Trophy className="w-20 h-20 text-yellow-500 mx-auto mb-6" />
+      </motion.div>
+      <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">Game Complete! 🧠</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        You've completed all {totalRounds} rounds of word association!
+      </p>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <Card>
+          <CardContent className="p-4 text-center">
+            <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">{score}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400">Total Score</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <div className="text-2xl font-bold text-green-600 dark:text-green-400">{Math.round(accuracy)}%</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400">Accuracy</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">{correctAnswers}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400">Perfect Rounds</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <div className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
+              {Math.floor(totalTime / 60)}:{(totalTime % 60).toString().padStart(2, '0')}
+            </div>
+            <div className="text-sm text-gray-600 dark:text-gray-400">Time Played</div>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="space-y-4">
+        <div className="flex gap-4 justify-center">
+          <Button onClick={resetGame} size="lg">
+            <RotateCcw className="w-4 h-4 mr-2" />
+            Play Again
+          </Button>
+          <Button variant="outline" onClick={onBack} size="lg">
+            <Home className="w-4 h-4 mr-2" />
+            Back to Games
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompletionScreen;

--- a/src/components/word-association/FeedbackModal.tsx
+++ b/src/components/word-association/FeedbackModal.tsx
@@ -44,9 +44,9 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                       Correct {currentRound.relationType === 'synonym' ? 'synonyms' : 'antonyms'}:
                     </p>
                     <div className="flex flex-wrap gap-1 justify-center">
-                      {currentRound.relatedWords.map((word) => (
+                      {currentRound.relatedWords.map((word, idx) => (
                         <Badge
-                          key={word}
+                          key={`${word}-${idx}`}
                           variant={currentRound.relationType === 'synonym' ? 'success' : 'destructive'}
                         >
                           {word}
@@ -58,8 +58,8 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                   <>
                     <p className="mb-2">Correct answers were:</p>
                     <div className="flex flex-wrap gap-1 justify-center">
-                      {currentRound.relatedWords.map((word) => (
-                        <Badge key={word} variant="success">
+                      {currentRound.relatedWords.map((word, idx) => (
+                        <Badge key={`${word}-${idx}`} variant="success">
                           {word}
                         </Badge>
                       ))}
@@ -68,9 +68,9 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                 )}
                 <p className="mt-4 mb-2">Your selections:</p>
                 <div className="flex flex-wrap gap-1 justify-center">
-                  {selectedWords.map((word) => (
+                  {selectedWords.map((word, idx) => (
                     <Badge
-                      key={word}
+                      key={`${word}-${idx}`}
                       variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}
                     >
                       {word}
@@ -86,8 +86,8 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                   <div className="mt-2">
                     <strong>Synonyms:</strong>
                     <div className="flex flex-wrap gap-1 mt-1 justify-center">
-                      {currentRound.synonyms.map((word) => (
-                        <Badge key={word} variant="success">
+                      {currentRound.synonyms.map((word, idx) => (
+                        <Badge key={`${word}-${idx}`} variant="success">
                           {word}
                         </Badge>
                       ))}
@@ -98,8 +98,8 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                   <div className="mt-2">
                     <strong>Antonyms:</strong>
                     <div className="flex flex-wrap gap-1 mt-1 justify-center">
-                      {currentRound.antonyms.map((word) => (
-                        <Badge key={word} variant="destructive">
+                      {currentRound.antonyms.map((word, idx) => (
+                        <Badge key={`${word}-${idx}`} variant="destructive">
                           {word}
                         </Badge>
                       ))}

--- a/src/components/word-association/FeedbackModal.tsx
+++ b/src/components/word-association/FeedbackModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Clock, Trophy, XCircle, CheckCircle } from 'lucide-react';
+import type { GameRound } from './types';
+
+interface FeedbackModalProps {
+  feedback: string | null;
+  currentRound: GameRound | null;
+  selectedWords: string[];
+  closeFeedback: () => void;
+}
+
+const FeedbackModal: React.FC<FeedbackModalProps> = ({
+  feedback,
+  currentRound,
+  selectedWords,
+  closeFeedback,
+}) => (
+  <>
+    {feedback && (
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -20 }}
+        className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+        onClick={closeFeedback}
+      >
+        <Card onClick={(e) => e.stopPropagation()}>
+          <CardContent className="p-8 text-center">
+            <div className="mb-4">
+              {feedback.includes('Perfect') && <Trophy className="w-12 h-12 text-yellow-500 mx-auto" />}
+              {feedback.includes('Partially') && <CheckCircle className="w-12 h-12 text-green-500 mx-auto" />}
+              {feedback.includes('Better luck') && <XCircle className="w-12 h-12 text-red-500 mx-auto" />}
+              {feedback.includes("Time's up") && <Clock className="w-12 h-12 text-orange-500 mx-auto" />}
+            </div>
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{feedback}</h3>
+            {currentRound && (
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-2">Correct answers were:</p>
+                <div className="flex flex-wrap gap-1 justify-center">
+                  {currentRound.relatedWords.map((word) => (
+                    <Badge key={word} variant="success">
+                      {word}
+                    </Badge>
+                  ))}
+                </div>
+                <p className="mt-4 mb-2">Your selections:</p>
+                <div className="flex flex-wrap gap-1 justify-center">
+                  {selectedWords.map((word) => (
+                    <Badge key={word} variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}>
+                      {word}
+                    </Badge>
+                  ))}
+                </div>
+                {currentRound.targetMeaning && (
+                  <p className="mt-4">
+                    <strong>Definition:</strong> {currentRound.targetMeaning}
+                  </p>
+                )}
+                {currentRound.synonyms && currentRound.synonyms.length > 0 && (
+                  <p className="mt-2">
+                    <strong>Synonyms:</strong> {currentRound.synonyms.join(', ')}
+                  </p>
+                )}
+                {currentRound.antonyms && currentRound.antonyms.length > 0 && (
+                  <p className="mt-2">
+                    <strong>Antonyms:</strong> {currentRound.antonyms.join(', ')}
+                  </p>
+                )}
+                {currentRound.guidewords && currentRound.guidewords.length > 0 && (
+                  <p className="mt-2">
+                    <strong>Guideword:</strong> {currentRound.guidewords.join(', ')}
+                  </p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </motion.div>
+    )}
+  </>
+);
+
+export default FeedbackModal;

--- a/src/components/word-association/FeedbackModal.tsx
+++ b/src/components/word-association/FeedbackModal.tsx
@@ -38,18 +38,41 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
             <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{feedback}</h3>
             {currentRound && (
               <div className="text-sm text-gray-600 dark:text-gray-400">
-                <p className="mb-2">Correct answers were:</p>
-                <div className="flex flex-wrap gap-1 justify-center">
-                  {currentRound.relatedWords.map((word) => (
-                    <Badge key={word} variant="success">
-                      {word}
-                    </Badge>
-                  ))}
-                </div>
+                {currentRound.relationType ? (
+                  <>
+                    <p className="mb-2">
+                      Correct {currentRound.relationType === 'synonym' ? 'synonyms' : 'antonyms'}:
+                    </p>
+                    <div className="flex flex-wrap gap-1 justify-center">
+                      {currentRound.relatedWords.map((word) => (
+                        <Badge
+                          key={word}
+                          variant={currentRound.relationType === 'synonym' ? 'success' : 'destructive'}
+                        >
+                          {word}
+                        </Badge>
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <p className="mb-2">Correct answers were:</p>
+                    <div className="flex flex-wrap gap-1 justify-center">
+                      {currentRound.relatedWords.map((word) => (
+                        <Badge key={word} variant="success">
+                          {word}
+                        </Badge>
+                      ))}
+                    </div>
+                  </>
+                )}
                 <p className="mt-4 mb-2">Your selections:</p>
                 <div className="flex flex-wrap gap-1 justify-center">
                   {selectedWords.map((word) => (
-                    <Badge key={word} variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}>
+                    <Badge
+                      key={word}
+                      variant={currentRound.relatedWords.includes(word) ? 'success' : 'destructive'}
+                    >
                       {word}
                     </Badge>
                   ))}

--- a/src/components/word-association/FeedbackModal.tsx
+++ b/src/components/word-association/FeedbackModal.tsx
@@ -60,14 +60,28 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                   </p>
                 )}
                 {currentRound.synonyms && currentRound.synonyms.length > 0 && (
-                  <p className="mt-2">
-                    <strong>Synonyms:</strong> {currentRound.synonyms.join(', ')}
-                  </p>
+                  <div className="mt-2">
+                    <strong>Synonyms:</strong>
+                    <div className="flex flex-wrap gap-1 mt-1 justify-center">
+                      {currentRound.synonyms.map((word) => (
+                        <Badge key={word} variant="success">
+                          {word}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
                 )}
                 {currentRound.antonyms && currentRound.antonyms.length > 0 && (
-                  <p className="mt-2">
-                    <strong>Antonyms:</strong> {currentRound.antonyms.join(', ')}
-                  </p>
+                  <div className="mt-2">
+                    <strong>Antonyms:</strong>
+                    <div className="flex flex-wrap gap-1 mt-1 justify-center">
+                      {currentRound.antonyms.map((word) => (
+                        <Badge key={word} variant="destructive">
+                          {word}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
                 )}
                 {currentRound.guidewords && currentRound.guidewords.length > 0 && (
                   <p className="mt-2">

--- a/src/components/word-association/PauseOverlay.tsx
+++ b/src/components/word-association/PauseOverlay.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent } from '../ui/card';
+import { Button } from '../ui/button';
+import { Play, Pause } from 'lucide-react';
+
+interface PauseOverlayProps {
+  isPaused: boolean;
+  togglePause: () => void;
+}
+
+const PauseOverlay: React.FC<PauseOverlayProps> = ({ isPaused, togglePause }) => (
+  <>
+    {isPaused && (
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      >
+        <Card>
+          <CardContent className="p-8 text-center">
+            <Pause className="w-12 h-24 text-gray-400 mx-auto mb-4" />
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">Game Paused</h3>
+            <Button onClick={togglePause}>
+              <Play className="w-4 h-4 mr-2" />
+              Resume Game
+            </Button>
+          </CardContent>
+        </Card>
+      </motion.div>
+    )}
+  </>
+);
+
+export default PauseOverlay;

--- a/src/components/word-association/SetupScreen.tsx
+++ b/src/components/word-association/SetupScreen.tsx
@@ -21,7 +21,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
 }) => {
   const getInfo = (level: 'easy' | 'medium' | 'hard') => {
     const seconds = level === 'easy' ? 45 : level === 'medium' ? 30 : 20;
-    const options = level === 'easy' ? 7 : level === 'medium' ? 10 : 13;
+    const options = level === 'easy' ? 8 : level === 'medium' ? 12 : 16;
     if (mode === 'vocabulary') {
       return `${seconds}s per round • ${options} words to choose from`;
     }

--- a/src/components/word-association/SetupScreen.tsx
+++ b/src/components/word-association/SetupScreen.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Brain, Play, Home } from 'lucide-react';
+import { Card, CardContent } from '../ui/card';
+import { Button } from '../ui/button';
+import type { GameMode } from './types';
+
+interface SetupScreenProps {
+  mode: GameMode;
+  setMode: (mode: GameMode) => void;
+  startGame: (level: 'easy' | 'medium' | 'hard') => void;
+  noWordsAvailable: boolean;
+  onBack: () => void;
+}
+
+const SetupScreen: React.FC<SetupScreenProps> = ({
+  mode,
+  setMode,
+  startGame,
+  noWordsAvailable,
+  onBack,
+}) => {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="text-center mb-8">
+        <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center mx-auto mb-4">
+          <Brain className="w-10 h-10 text-white" />
+        </div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">Word Association Game</h2>
+        <p className="text-gray-600 dark:text-gray-400">
+          {mode === 'vocabulary'
+            ? 'Find words related to the target word. Test your vocabulary knowledge and word connections!'
+            : mode === 'idiom'
+            ? 'Select the correct meaning for the displayed idiom.'
+            : mode === 'phrasal verb'
+            ? 'Select the correct meaning for the displayed phrasal verb.'
+            : (
+                <>Choose words that are <span className="font-bold text-green-600">synonyms</span> or <span className="font-bold text-red-600">antonyms</span> of the target word.</>
+              )}
+        </p>
+      </div>
+      <div className="flex justify-center gap-2 mb-6">
+        {[
+          { id: 'vocabulary', label: 'Vocabulary' },
+          { id: 'idiom', label: 'Idioms' },
+          { id: 'phrasal verb', label: 'Phrasal Verbs' },
+          { id: 'syn-ant', label: 'Synonyms & Antonyms' },
+        ].map((m) => (
+          <Button key={m.id} variant={mode === m.id ? 'default' : 'outline'} onClick={() => setMode(m.id as GameMode)}>
+            {m.label}
+          </Button>
+        ))}
+      </div>
+      <div className="grid md:grid-cols-3 gap-4 mb-8">
+        {(['easy', 'medium', 'hard'] as const).map((level) => (
+          <Card
+            key={level}
+            className="cursor-pointer hover:shadow-lg transition-all duration-300 hover:scale-105"
+            onClick={() => startGame(level)}
+          >
+            <CardContent className="p-6 text-center">
+              <div
+                className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 ${
+                  level === 'easy'
+                    ? 'bg-green-100 dark:bg-green-900/20'
+                    : level === 'medium'
+                    ? 'bg-yellow-100 dark:bg-yellow-900/20'
+                    : 'bg-red-100 dark:bg-red-900/20'
+                }`}
+              >
+                <Brain
+                  className={`w-6 h-6 ${
+                    level === 'easy'
+                      ? 'text-green-600 dark:text-green-400'
+                      : level === 'medium'
+                      ? 'text-yellow-600 dark:text-yellow-400'
+                      : 'text-red-600 dark:text-red-400'
+                  }`}
+                />
+              </div>
+              <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-2 capitalize">{level}</h3>
+              <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                {level === 'easy' && '45s per round • 7 words to choose from'}
+                {level === 'medium' && '30s per round • 10 words to choose from'}
+                {level === 'hard' && '20s per round • 13 words to choose from'}
+              </div>
+              <Button className="w-full" disabled={noWordsAvailable}>
+                <Play className="w-4 h-4 mr-2" />
+                Start Game
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+        {noWordsAvailable && (
+          <div className="col-span-full text-center text-gray-500 dark:text-gray-400">
+            No words available for this mode.
+          </div>
+        )}
+      </div>
+      <div className="text-center">
+        <Button variant="outline" onClick={onBack}>
+          <Home className="w-4 h-4 mr-2" />
+          Back to Games
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default SetupScreen;

--- a/src/components/word-association/SetupScreen.tsx
+++ b/src/components/word-association/SetupScreen.tsx
@@ -19,6 +19,17 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
   noWordsAvailable,
   onBack,
 }) => {
+  const getInfo = (level: 'easy' | 'medium' | 'hard') => {
+    const seconds = level === 'easy' ? 45 : level === 'medium' ? 30 : 20;
+    const options = level === 'easy' ? 7 : level === 'medium' ? 10 : 13;
+    if (mode === 'vocabulary') {
+      return `${seconds}s per round • ${options} words to choose from`;
+    }
+    if (mode === 'syn-ant') {
+      return `${seconds}s per round • ${options} synonym/antonym options`;
+    }
+    return `${seconds}s per round • ${options} meanings to choose from`;
+  };
   return (
     <div className="max-w-4xl mx-auto">
       <div className="text-center mb-8">
@@ -79,9 +90,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({
               </div>
               <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-2 capitalize">{level}</h3>
               <div className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                {level === 'easy' && '45s per round • 7 words to choose from'}
-                {level === 'medium' && '30s per round • 10 words to choose from'}
-                {level === 'hard' && '20s per round • 13 words to choose from'}
+                {getInfo(level)}
               </div>
               <Button className="w-full" disabled={noWordsAvailable}>
                 <Play className="w-4 h-4 mr-2" />

--- a/src/components/word-association/modes/idiom.ts
+++ b/src/components/word-association/modes/idiom.ts
@@ -1,0 +1,56 @@
+import type { WordGroup, WordItem, GameRound } from '../types';
+
+const parseList = (val?: string | null): string[] =>
+  val ? val.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+export const fetchIdiomGroups = async (apiUrl: string): Promise<WordGroup[]> => {
+  const res = await fetch(`${apiUrl}lexicon/groups?type=idiom&limit=50`);
+  const data = await res.json();
+  if (data.response) {
+    return data.response
+      .map((g: any) => ({
+        ...g,
+        words: g.words.map((w: any) =>
+          typeof w === 'string'
+            ? { text: w }
+            : {
+                text: w.expression,
+                meaning: w.meaning,
+                synonyms: w.synonyms,
+                antonyms: w.antonyms,
+                related: w.related,
+                guideword: w.guideword,
+              }
+        ),
+      }))
+      .filter((g: any) => g.words.length > 0);
+  }
+  return [];
+};
+
+export const buildIdiomRound = (
+  group: WordGroup,
+  item: WordItem,
+  roundNum: number,
+  difficulty: 'easy' | 'medium' | 'hard',
+  allMeanings: string[]
+): GameRound => {
+  const targetWord = item.text;
+  const targetMeaning = item.meaning as string;
+  const totalOptions = difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
+  const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
+  const selectedDistractors = availableDistractors
+    .sort(() => Math.random() - 0.5)
+    .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
+  const allOptions = [targetMeaning, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+  return {
+    id: `round-${roundNum}`,
+    targetWord,
+    targetMeaning,
+    relatedWords: [targetMeaning],
+    distractors: selectedDistractors,
+    allOptions,
+    theme: group.theme,
+  };
+};

--- a/src/components/word-association/modes/idiom.ts
+++ b/src/components/word-association/modes/idiom.ts
@@ -37,7 +37,7 @@ export const buildIdiomRound = (
 ): GameRound => {
   const targetWord = item.text;
   const targetMeaning = item.meaning as string;
-  const totalOptions = difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
+  const totalOptions = difficulty === 'easy' ? 8 : difficulty === 'medium' ? 12 : 16;
   const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
   const selectedDistractors = availableDistractors
     .sort(() => Math.random() - 0.5)

--- a/src/components/word-association/modes/phrasalVerb.ts
+++ b/src/components/word-association/modes/phrasalVerb.ts
@@ -1,4 +1,58 @@
 import type { WordGroup, WordItem, GameRound } from '../types';
 
-export { fetchIdiomGroups as fetchPhrasalVerbGroups } from './idiom';
-export { buildIdiomRound as buildPhrasalVerbRound } from './idiom';
+export const fetchPhrasalVerbGroups = async (
+  apiUrl: string
+): Promise<WordGroup[]> => {
+  const res = await fetch(`${apiUrl}lexicon/groups?type=phrasal%20verb&limit=50`);
+  const data = await res.json();
+  if (data.response) {
+    return data.response
+      .map((g: any) => ({
+        ...g,
+        words: g.words.map((w: any) =>
+          typeof w === 'string'
+            ? { text: w }
+            : {
+                text: w.expression,
+                meaning: w.meaning,
+                synonyms: w.synonyms,
+                antonyms: w.antonyms,
+                related: w.related,
+                guideword: w.guideword,
+              }
+        ),
+      }))
+      .filter((g: any) => g.words.length > 0);
+  }
+  return [];
+};
+
+export const buildPhrasalVerbRound = (
+  group: WordGroup,
+  item: WordItem,
+  roundNum: number,
+  difficulty: 'easy' | 'medium' | 'hard',
+  allMeanings: string[]
+): GameRound => {
+  const targetWord = item.text;
+  const targetMeaning = item.meaning as string;
+  const totalOptions =
+    difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
+  const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
+  const selectedDistractors = availableDistractors
+    .sort(() => Math.random() - 0.5)
+    .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
+  const allOptions = [targetMeaning, ...selectedDistractors].sort(
+    () => Math.random() - 0.5
+  );
+
+  return {
+    id: `round-${roundNum}`,
+    targetWord,
+    targetMeaning,
+    relatedWords: [targetMeaning],
+    distractors: selectedDistractors,
+    allOptions,
+    theme: group.theme,
+  };
+};

--- a/src/components/word-association/modes/phrasalVerb.ts
+++ b/src/components/word-association/modes/phrasalVerb.ts
@@ -38,13 +38,15 @@ export const buildPhrasalVerbRound = (
   const targetMeaning = item.meaning as string;
   const totalOptions =
     difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
-  const availableDistractors = allMeanings.filter(m => m !== targetMeaning);
+  const availableDistractors = Array.from(
+    new Set(allMeanings.filter(m => m !== targetMeaning))
+  );
   const selectedDistractors = availableDistractors
     .sort(() => Math.random() - 0.5)
     .slice(0, Math.min(totalOptions - 1, availableDistractors.length));
-  const allOptions = [targetMeaning, ...selectedDistractors].sort(
-    () => Math.random() - 0.5
-  );
+  const allOptions = Array.from(
+    new Set([targetMeaning, ...selectedDistractors])
+  ).sort(() => Math.random() - 0.5);
 
   return {
     id: `round-${roundNum}`,

--- a/src/components/word-association/modes/phrasalVerb.ts
+++ b/src/components/word-association/modes/phrasalVerb.ts
@@ -1,0 +1,4 @@
+import type { WordGroup, WordItem, GameRound } from '../types';
+
+export { fetchIdiomGroups as fetchPhrasalVerbGroups } from './idiom';
+export { buildIdiomRound as buildPhrasalVerbRound } from './idiom';

--- a/src/components/word-association/modes/phrasalVerb.ts
+++ b/src/components/word-association/modes/phrasalVerb.ts
@@ -37,7 +37,7 @@ export const buildPhrasalVerbRound = (
   const targetWord = item.text;
   const targetMeaning = item.meaning as string;
   const totalOptions =
-    difficulty === 'easy' ? 7 : difficulty === 'medium' ? 10 : 13;
+    difficulty === 'easy' ? 8 : difficulty === 'medium' ? 12 : 16;
   const availableDistractors = Array.from(
     new Set(allMeanings.filter(m => m !== targetMeaning))
   );

--- a/src/components/word-association/modes/synAnt.ts
+++ b/src/components/word-association/modes/synAnt.ts
@@ -1,0 +1,71 @@
+import type { WordGroup, WordItem, GameRound, RelationType } from '../types';
+
+const parseList = (val?: string | null): string[] =>
+  val ? val.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+export const fetchSynAntGroups = async (apiUrl: string): Promise<WordGroup[]> => {
+  const res = await fetch(`${apiUrl}lexicon/words?limit=200`);
+  const data = await res.json();
+  if (data.response) {
+    const words = data.response
+      .filter((w: any) => w.Synonyms && w.Antonyms)
+      .map((w: any) => ({
+        text: w.Word,
+        meaning: w.Definition,
+        synonyms: w.Synonyms,
+        antonyms: w.Antonyms,
+        guideword: w.Guideword,
+        related: w.RelatedLexicon,
+      }));
+    return [
+      {
+        id: 'syn-ant',
+        theme: 'Synonyms & Antonyms',
+        words,
+        description: '',
+      },
+    ];
+  }
+  return [];
+};
+
+export const buildSynAntRound = (
+  group: WordGroup,
+  item: WordItem,
+  roundNum: number,
+  distractors: string[],
+  difficulty: 'easy' | 'medium' | 'hard'
+): GameRound => {
+  const targetWord = item.text;
+  const synonyms = parseList(item.synonyms);
+  const antonyms = parseList(item.antonyms);
+  const useSynonyms = Math.random() < 0.5;
+  const relationType: RelationType = useSynonyms ? 'synonym' : 'antonym';
+  const relatedSet = useSynonyms ? synonyms : antonyms;
+  const allRelated = [...synonyms, ...antonyms];
+
+  const relatedWords = relatedSet
+    .sort(() => Math.random() - 0.5)
+    .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+
+  const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+  const exclude = [targetWord, ...allRelated];
+  const selectedDistractors = distractors
+    .filter(w => !exclude.some(ex => w.toLowerCase().includes(ex.toLowerCase())))
+    .sort(() => Math.random() - 0.5)
+    .slice(0, numDistractors);
+  const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+  return {
+    id: `round-${roundNum}`,
+    targetWord,
+    targetMeaning: item.meaning,
+    synonyms,
+    antonyms,
+    relatedWords,
+    distractors: selectedDistractors,
+    allOptions,
+    theme: group.theme,
+    relationType,
+  };
+};

--- a/src/components/word-association/modes/synAnt.ts
+++ b/src/components/word-association/modes/synAnt.ts
@@ -37,9 +37,12 @@ export const buildSynAntRound = (
   const targetWord = item.text;
   const synonyms = parseList(item.synonyms);
   const antonyms = parseList(item.antonyms);
-  const useSynonyms = Math.random() < 0.5;
-  const relationType: RelationType = useSynonyms ? 'synonym' : 'antonym';
-  const relatedSet = useSynonyms ? synonyms : antonyms;
+  const available: RelationType[] = [];
+  if (synonyms.length > 0) available.push('synonym');
+  if (antonyms.length > 0) available.push('antonym');
+  const relationType: RelationType =
+    available[Math.floor(Math.random() * available.length)];
+  const relatedSet = relationType === 'synonym' ? synonyms : antonyms;
   const allRelated = [...synonyms, ...antonyms];
 
   const relatedWords = relatedSet

--- a/src/components/word-association/modes/synAnt.ts
+++ b/src/components/word-association/modes/synAnt.ts
@@ -45,11 +45,14 @@ export const buildSynAntRound = (
   const relatedSet = relationType === 'synonym' ? synonyms : antonyms;
   const allRelated = [...synonyms, ...antonyms];
 
+  const totalOptions = difficulty === 'easy' ? 8 : difficulty === 'medium' ? 12 : 16;
+  const maxCorrect = Math.floor(totalOptions * 0.25);
+
   const relatedWords = relatedSet
     .sort(() => Math.random() - 0.5)
-    .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+    .slice(0, Math.min(maxCorrect, relatedSet.length));
 
-  const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+  const numDistractors = totalOptions - relatedWords.length;
   const exclude = [targetWord, ...allRelated];
   const selectedDistractors = distractors
     .filter(w => !exclude.some(ex => w.toLowerCase().includes(ex.toLowerCase())))

--- a/src/components/word-association/modes/synAnt.ts
+++ b/src/components/word-association/modes/synAnt.ts
@@ -4,19 +4,17 @@ const parseList = (val?: string | null): string[] =>
   val ? val.split(',').map(s => s.trim()).filter(Boolean) : [];
 
 export const fetchSynAntGroups = async (apiUrl: string): Promise<WordGroup[]> => {
-  const res = await fetch(`${apiUrl}lexicon/words?limit=200`);
+  const res = await fetch(`${apiUrl}lexicon/words?synAnt=true&limit=200`);
   const data = await res.json();
   if (data.response) {
-    const words = data.response
-      .filter((w: any) => w.Synonyms && w.Antonyms)
-      .map((w: any) => ({
-        text: w.Word,
-        meaning: w.Definition,
-        synonyms: w.Synonyms,
-        antonyms: w.Antonyms,
-        guideword: w.Guideword,
-        related: w.RelatedLexicon,
-      }));
+    const words = data.response.map((w: any) => ({
+      text: w.Word,
+      meaning: w.Definition,
+      synonyms: w.Synonyms,
+      antonyms: w.Antonyms,
+      guideword: w.Guideword,
+      related: w.RelatedLexicon,
+    }));
     return [
       {
         id: 'syn-ant',

--- a/src/components/word-association/modes/vocabulary.ts
+++ b/src/components/word-association/modes/vocabulary.ts
@@ -1,0 +1,72 @@
+import type { WordGroup, WordItem, GameRound } from '../types';
+
+const parseList = (val?: string | null): string[] =>
+  val ? val.split(',').map(s => s.trim()).filter(Boolean) : [];
+
+export const fetchVocabularyGroups = async (apiUrl: string): Promise<WordGroup[]> => {
+  const res = await fetch(`${apiUrl}lexicon/groups?type=vocabulary&limit=50`);
+  const data = await res.json();
+  if (data.response) {
+    return data.response
+      .map((g: any) => ({
+        ...g,
+        words: g.words.map((w: any) =>
+          typeof w === 'string'
+            ? { text: w }
+            : {
+                text: w.expression,
+                meaning: w.meaning,
+                synonyms: w.synonyms,
+                antonyms: w.antonyms,
+                related: w.related,
+                guideword: w.guideword,
+              }
+        ),
+      }))
+      .filter((g: any) => g.words.length > 0);
+  }
+  return [];
+};
+
+export const buildVocabularyRound = (
+  group: WordGroup,
+  item: WordItem,
+  roundNum: number,
+  distractors: string[],
+  difficulty: 'easy' | 'medium' | 'hard'
+): GameRound => {
+  const targetWord = item.text;
+  const synonyms = parseList(item.synonyms);
+  const related = parseList(item.related);
+  const guidewords = parseList(item.guideword);
+
+  let relatedSet = Array.from(new Set([...synonyms, ...related]));
+  if (relatedSet.length === 0) {
+    relatedSet = group.words.filter(w => w.text !== targetWord).map(w => w.text);
+  }
+
+  const relatedWords = relatedSet
+    .filter(w => w.toLowerCase() !== targetWord.toLowerCase())
+    .sort(() => Math.random() - 0.5)
+    .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+
+  const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+  const selectedDistractors = distractors
+    .filter(w => w !== targetWord && !relatedSet.includes(w))
+    .sort(() => Math.random() - 0.5)
+    .slice(0, numDistractors);
+
+  const allOptions = [...relatedWords, ...selectedDistractors].sort(() => Math.random() - 0.5);
+
+  return {
+    id: `round-${roundNum}`,
+    targetWord,
+    targetMeaning: item.meaning,
+    synonyms,
+    guidewords,
+    relatedWords,
+    distractors: selectedDistractors,
+    allOptions,
+    theme: group.theme,
+  };
+};

--- a/src/components/word-association/modes/vocabulary.ts
+++ b/src/components/word-association/modes/vocabulary.ts
@@ -45,12 +45,15 @@ export const buildVocabularyRound = (
     relatedSet = group.words.filter(w => w.text !== targetWord).map(w => w.text);
   }
 
+  const totalOptions = difficulty === 'easy' ? 8 : difficulty === 'medium' ? 12 : 16;
+  const maxCorrect = Math.floor(totalOptions * 0.25);
+
   const relatedWords = relatedSet
     .filter(w => w.toLowerCase() !== targetWord.toLowerCase())
     .sort(() => Math.random() - 0.5)
-    .slice(0, difficulty === 'easy' ? 3 : difficulty === 'medium' ? 4 : 5);
+    .slice(0, Math.min(maxCorrect, relatedSet.length));
 
-  const numDistractors = difficulty === 'easy' ? 4 : difficulty === 'medium' ? 6 : 8;
+  const numDistractors = totalOptions - relatedWords.length;
   const selectedDistractors = distractors
     .filter(w => w !== targetWord && !relatedSet.includes(w))
     .sort(() => Math.random() - 0.5)

--- a/src/components/word-association/types.ts
+++ b/src/components/word-association/types.ts
@@ -1,0 +1,33 @@
+export interface WordItem {
+  text: string;
+  meaning?: string;
+  synonyms?: string | null;
+  antonyms?: string | null;
+  related?: string | null;
+  guideword?: string | null;
+}
+
+export interface WordGroup {
+  id: string;
+  theme: string;
+  words: WordItem[];
+  description: string;
+}
+
+export type RelationType = 'synonym' | 'antonym';
+
+export interface GameRound {
+  id: string;
+  targetWord: string;
+  targetMeaning?: string;
+  synonyms?: string[];
+  antonyms?: string[];
+  guidewords?: string[];
+  relatedWords: string[];
+  distractors: string[];
+  allOptions: string[];
+  theme: string;
+  relationType?: RelationType;
+}
+
+export type GameMode = 'vocabulary' | 'idiom' | 'phrasal verb' | 'syn-ant';


### PR DESCRIPTION
## Summary
- expand `WordItem` and `GameRound` to support antonyms
- fetch words containing synonyms and antonyms when in the new mode
- refactor round generation into helper functions
- add UI text and controls for the new mode
- display antonyms in the feedback panel

## Testing
- `npm run lint` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68556aaae6a0833089de6b7ae7640a2c