### PR TITLE
Fix memory challenge quiz start

### DIFF
--- a/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
+++ b/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
@@ -228,6 +228,11 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
 
   // PHASE 2: Quiz
   if (phase === "quiz") {
+    if (quizQuestions.length === 0) {
+      return (
+        <div className="text-center py-10 text-lg">Preparing questions...</div>
+      );
+    }
     const q = quizQuestions[quizIndex];
     return (
       <div className="flex flex-col items-center justify-center py-12">


### PR DESCRIPTION
## Summary
- ensure Memory Challenge waits for quiz questions

## Testing
- `npm run build`
- `npm test` *(fails: `ReferenceError: require is not defined in ES module scope`)*

------
https://chatgpt.com/codex/tasks/task_e_6855e17929a083309f7541af8564d963