### PR TITLE
Fix memory challenge quiz start

### DIFF
--- a/src/components/games/FlashcardMemoryGame/FlashcardMemoryGame.tsx
+++ b/src/components/games/FlashcardMemoryGame/FlashcardMemoryGame.tsx
@@ -280,13 +280,22 @@ const FlashcardMemoryGame: React.FC<FlashcardMemoryGameProps> = ({
         ? (gameSession.correctAnswers / gameSession.totalAnswers) * 100
         : 0;
     const memorizedCount = flashcards.filter((card) => card.memorized).length;
+    const correctWords = flashcards.filter(
+      (card) => !incorrectWords.some((w) => w.id === card.id)
+    );
+    const missedWords =
+      gameSession.totalAnswers < flashcards.length
+        ? flashcards.slice(gameSession.totalAnswers)
+        : [];
     return (
       <GameCompletion
         score={gameSession.score}
         accuracy={accuracy}
         memorizedCount={memorizedCount}
         time={formatTime(gameSession.timeElapsed)}
+        correctWords={correctWords}
         incorrectWords={incorrectWords}
+        missedWords={missedWords}
         onPlayAgain={resetGame}
         onBack={onBack}
       />

--- a/src/components/games/FlashcardMemoryGame/FlashcardMemoryGame.tsx
+++ b/src/components/games/FlashcardMemoryGame/FlashcardMemoryGame.tsx
@@ -59,6 +59,12 @@ const FlashcardMemoryGame: React.FC<FlashcardMemoryGameProps> = ({
   const [lexiconType, setLexiconType] =
     useState<'vocabulary' | 'idiom' | 'phrasal verb'>("vocabulary");
   const [timer, setTimer] = useState(0);
+  const [memoryHeader, setMemoryHeader] = useState({
+    current: 0,
+    total: 0,
+    score: 0,
+    timer: undefined as number | undefined,
+  });
 
   // Quiz-specific
   const [quizOptions, setQuizOptions] = useState<string[]>([]);
@@ -291,14 +297,24 @@ const FlashcardMemoryGame: React.FC<FlashcardMemoryGameProps> = ({
   const currentCard = flashcards[gameSession.currentCardIndex];
   if (!currentCard) return null;
 
+  const headerTimer =
+    gameMode === "memory" && memoryHeader.timer !== undefined
+      ? `${memoryHeader.timer}s`
+      : formatTime(timer);
+  const headerCurrent =
+    gameMode === "memory" ? memoryHeader.current : gameSession.currentCardIndex + 1;
+  const headerTotal =
+    gameMode === "memory" ? memoryHeader.total : flashcards.length;
+  const headerScore = gameMode === "memory" ? memoryHeader.score : gameSession.score;
+
   return (
     <div className="max-w-4xl mx-auto">
       <GameHeader
         gameMode={gameMode}
-        timer={formatTime(timer)}
-        currentIndex={gameSession.currentCardIndex + 1}
-        totalCards={flashcards.length}
-        score={gameSession.score}
+        timer={headerTimer}
+        currentIndex={headerCurrent}
+        totalCards={headerTotal}
+        score={headerScore}
         isPaused={isPaused}
         onPauseToggle={togglePause}
         onShuffle={shuffleCards}
@@ -331,13 +347,7 @@ const FlashcardMemoryGame: React.FC<FlashcardMemoryGameProps> = ({
       {gameMode === "memory" && (
         <MemoryChallenge
           flashcards={flashcards}
-          currentCard={currentCard}
-          showAnswer={gameSession.showAnswer}
-          onToggleAnswer={toggleAnswer}
-          onNextCard={nextCard}
-          onPreviousCard={previousCard}
-          isFirst={gameSession.currentCardIndex === 0}
-          isLast={gameSession.currentCardIndex === flashcards.length - 1}
+          onHeaderUpdate={setMemoryHeader}
         />
       )}
     </div>

--- a/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
+++ b/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
@@ -63,14 +63,14 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
       </div>
     </div>
     {(correctWords.length > 0 || incorrectWords.length > 0 || missedWords.length > 0) && (
-      <div className="grid md:grid-cols-3 gap-4 mb-8 text-left">
+      <div className="space-y-4 mb-8 text-left">
         {correctWords.length > 0 && (
-          <Accordion className="border rounded">
+          <Accordion className="border rounded w-full">
             <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
               Correct Words ({correctWords.length})
             </AccordionSummary>
             <AccordionDetails>
-              <ul className="list-disc list-inside space-y-1">
+              <ul className="list-disc pl-5 text-gray-600 dark:text-gray-300 space-y-1">
                 {correctWords.map((card, idx) => (
                   <li key={`${card.id}-${idx}`}>
                     <span className="font-medium">{card.word}</span> - {card.definition}
@@ -81,12 +81,12 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
           </Accordion>
         )}
         {incorrectWords.length > 0 && (
-          <Accordion className="border rounded">
+          <Accordion className="border rounded w-full">
             <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
               Incorrect Words ({incorrectWords.length})
             </AccordionSummary>
             <AccordionDetails>
-              <ul className="list-disc list-inside space-y-1">
+              <ul className="list-disc pl-5 text-gray-600 dark:text-gray-300 space-y-1">
                 {incorrectWords.map((card, idx) => (
                   <li key={`${card.id}-${idx}`}>
                     <span className="font-medium">{card.word}</span> - {card.definition}
@@ -97,12 +97,12 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
           </Accordion>
         )}
         {missedWords.length > 0 && (
-          <Accordion className="border rounded">
+          <Accordion className="border rounded w-full">
             <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
               Missed Words ({missedWords.length})
             </AccordionSummary>
             <AccordionDetails>
-              <ul className="list-disc list-inside space-y-1">
+              <ul className="list-disc pl-5 text-gray-600 dark:text-gray-300 space-y-1">
                 {missedWords.map((card, idx) => (
                   <li key={`${card.id}-${idx}`}>
                     <span className="font-medium">{card.word}</span> - {card.definition}

--- a/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
+++ b/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Button } from "../../ui/button";
 import { Card, CardHeader, CardContent } from "../../ui/card";
-import { Trophy, RotateCcw, Home } from "lucide-react";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import { Trophy, RotateCcw, Home, ChevronDown } from "lucide-react";
 
 interface FlashcardData {
   id: string;
@@ -62,9 +65,11 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
     {(correctWords.length > 0 || incorrectWords.length > 0 || missedWords.length > 0) && (
       <div className="grid md:grid-cols-3 gap-4 mb-8 text-left">
         {correctWords.length > 0 && (
-          <Card>
-            <CardHeader className="font-semibold">Correct Words</CardHeader>
-            <CardContent>
+          <Accordion className="border rounded">
+            <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
+              Correct Words ({correctWords.length})
+            </AccordionSummary>
+            <AccordionDetails>
               <ul className="list-disc list-inside space-y-1">
                 {correctWords.map((card, idx) => (
                   <li key={`${card.id}-${idx}`}>
@@ -72,36 +77,40 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
                   </li>
                 ))}
               </ul>
-            </CardContent>
-          </Card>
+            </AccordionDetails>
+          </Accordion>
         )}
         {incorrectWords.length > 0 && (
-          <Card>
-            <CardHeader className="font-semibold">Incorrect Words</CardHeader>
-            <CardContent>
+          <Accordion className="border rounded">
+            <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
+              Incorrect Words ({incorrectWords.length})
+            </AccordionSummary>
+            <AccordionDetails>
               <ul className="list-disc list-inside space-y-1">
                 {incorrectWords.map((card, idx) => (
-                  <li key={`${card.id}-${idx}`}> 
+                  <li key={`${card.id}-${idx}`}>
                     <span className="font-medium">{card.word}</span> - {card.definition}
                   </li>
                 ))}
               </ul>
-            </CardContent>
-          </Card>
+            </AccordionDetails>
+          </Accordion>
         )}
         {missedWords.length > 0 && (
-          <Card>
-            <CardHeader className="font-semibold">Missed Words</CardHeader>
-            <CardContent>
+          <Accordion className="border rounded">
+            <AccordionSummary expandIcon={<ChevronDown className="w-4 h-4" />} className="font-semibold">
+              Missed Words ({missedWords.length})
+            </AccordionSummary>
+            <AccordionDetails>
               <ul className="list-disc list-inside space-y-1">
                 {missedWords.map((card, idx) => (
-                  <li key={`${card.id}-${idx}`}> 
+                  <li key={`${card.id}-${idx}`}>
                     <span className="font-medium">{card.word}</span> - {card.definition}
                   </li>
                 ))}
               </ul>
-            </CardContent>
-          </Card>
+            </AccordionDetails>
+          </Accordion>
         )}
       </div>
     )}

--- a/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
+++ b/src/components/games/FlashcardMemoryGame/GameCompletion.tsx
@@ -1,13 +1,40 @@
 import React from "react";
 import { Button } from "../../ui/button";
+import { Card, CardHeader, CardContent } from "../../ui/card";
 import { Trophy, RotateCcw, Home } from "lucide-react";
 
-const GameCompletion = ({
+interface FlashcardData {
+  id: string;
+  word: string;
+  definition: string;
+  example: string;
+  difficulty: "easy" | "medium" | "hard";
+  category: string;
+  memorized: boolean;
+  attempts: number;
+  correctStreak: number;
+}
+
+interface GameCompletionProps {
+  score: number;
+  accuracy: number;
+  memorizedCount: number;
+  time: string;
+  correctWords: FlashcardData[];
+  incorrectWords: FlashcardData[];
+  missedWords: FlashcardData[];
+  onPlayAgain: () => void;
+  onBack: () => void;
+}
+
+const GameCompletion: React.FC<GameCompletionProps> = ({
   score,
   accuracy,
   memorizedCount,
   time,
+  correctWords,
   incorrectWords,
+  missedWords,
   onPlayAgain,
   onBack,
 }) => (
@@ -32,16 +59,50 @@ const GameCompletion = ({
         <div className="text-sm text-gray-600">Time</div>
       </div>
     </div>
-    {incorrectWords.length > 0 && (
-      <div className="mb-8 text-left">
-        <h3 className="font-semibold mb-2">Missed Words</h3>
-        <ul className="list-disc list-inside space-y-1">
-          {incorrectWords.map(card => (
-            <li key={card.id}>
-              <span className="font-medium">{card.word}</span> - {card.definition}
-            </li>
-          ))}
-        </ul>
+    {(correctWords.length > 0 || incorrectWords.length > 0 || missedWords.length > 0) && (
+      <div className="grid md:grid-cols-3 gap-4 mb-8 text-left">
+        {correctWords.length > 0 && (
+          <Card>
+            <CardHeader className="font-semibold">Correct Words</CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {correctWords.map((card, idx) => (
+                  <li key={`${card.id}-${idx}`}>
+                    <span className="font-medium">{card.word}</span> - {card.definition}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+        {incorrectWords.length > 0 && (
+          <Card>
+            <CardHeader className="font-semibold">Incorrect Words</CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {incorrectWords.map((card, idx) => (
+                  <li key={`${card.id}-${idx}`}> 
+                    <span className="font-medium">{card.word}</span> - {card.definition}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+        {missedWords.length > 0 && (
+          <Card>
+            <CardHeader className="font-semibold">Missed Words</CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside space-y-1">
+                {missedWords.map((card, idx) => (
+                  <li key={`${card.id}-${idx}`}> 
+                    <span className="font-medium">{card.word}</span> - {card.definition}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
       </div>
     )}
     <Button onClick={onPlayAgain} size="lg">

--- a/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
+++ b/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
@@ -4,48 +4,13 @@ import { Button } from "../../ui/button";
 import { Progress } from "../../ui/progress";
 import { Badge } from "../../ui/badge";
 import {
-  Play,
   RotateCcw,
   Trophy,
   Timer,
   ArrowLeft,
   ArrowRight,
-  Target,
-  Star,
 } from "lucide-react";
 
-const ChallengeHeader: React.FC<{
-  current: number;
-  total: number;
-  score: number;
-  timer?: number;
-}> = ({ current, total, score, timer }) => (
-  <div className="flex flex-wrap items-center justify-between mb-6 gap-4">
-    <div className="flex items-center gap-3">
-      <span className="font-bold text-xl tracking-wide bg-gradient-to-r from-purple-400 to-pink-600 bg-clip-text text-transparent">
-        Memory Challenge
-      </span>
-      <span className="flex items-center gap-1 px-3 py-1 rounded-full bg-purple-900/50 border border-purple-700">
-        <Target className="w-4 h-4 text-purple-400" />
-        <span className="font-semibold text-purple-200">
-          Card: {current}/{total}
-        </span>
-      </span>
-      <span className="flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-900/40 border border-yellow-600">
-        <Star className="w-4 h-4 text-yellow-300" />
-        <span className="font-semibold text-yellow-200">Score: {score}</span>
-      </span>
-      {typeof timer === "number" && (
-        <span className="flex items-center gap-1 px-4 py-1 rounded-full bg-blue-900/50 shadow-inner border border-blue-600">
-          <Timer className="w-5 h-5 text-blue-400" />
-          <span className="font-mono text-lg tracking-widest text-blue-200">
-            {timer}s
-          </span>
-        </span>
-      )}
-    </div>
-  </div>
-);
 
 interface FlashcardData {
   id: string;
@@ -61,13 +26,22 @@ interface FlashcardData {
 
 interface MemoryChallengeProps {
   flashcards?: FlashcardData[];
+  onHeaderUpdate?: (data: {
+    current: number;
+    total: number;
+    score: number;
+    timer?: number;
+  }) => void;
 }
 
 const CHALLENGE_LENGTH = 10;
 const FLASHCARD_INTERVAL = 2000;
 const QUIZ_TIME_LIMIT = 5;
 
-const MemoryChallenge: React.FC<MemoryChallengeProps> = ({ flashcards = [] }) => {
+const MemoryChallenge: React.FC<MemoryChallengeProps> = ({
+  flashcards = [],
+  onHeaderUpdate,
+}) => {
   const [phase, setPhase] = useState<"show" | "quiz" | "results">("show");
   const [showIndex, setShowIndex] = useState(0);
 
@@ -161,6 +135,19 @@ const MemoryChallenge: React.FC<MemoryChallengeProps> = ({ flashcards = [] }) =>
       if (timerRef.current) clearInterval(timerRef.current);
     };
   }, [phase, quizIndex, quizQuestions.length]);
+
+  // Notify parent of header updates
+  useEffect(() => {
+    if (!onHeaderUpdate) return;
+    const current = phase === "show" ? showIndex + 1 : quizIndex + 1;
+    const total = phase === "show" ? CHALLENGE_LENGTH : quizQuestions.length;
+    onHeaderUpdate({
+      current,
+      total,
+      score,
+      timer: phase === "quiz" ? timer : undefined,
+    });
+  }, [onHeaderUpdate, phase, showIndex, quizIndex, quizQuestions.length, score, timer]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -282,7 +269,6 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
     const card = flashcards[showIndex];
     return (
       <div className="flex flex-col items-center justify-center py-12">
-        <ChallengeHeader current={showIndex + 1} total={CHALLENGE_LENGTH} score={score} />
         <Card className="w-full max-w-xl text-center border shadow-md">
           <CardHeader>
             <div className="flex justify-between items-center">
@@ -340,12 +326,6 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
     const q = quizQuestions[quizIndex];
     return (
       <div className="flex flex-col items-center justify-center py-12">
-        <ChallengeHeader
-          current={quizIndex + 1}
-          total={quizQuestions.length}
-          score={score}
-          timer={timer}
-        />
         <Card className="w-full max-w-xl text-center border shadow-md">
           <CardHeader>
             <div className="flex justify-between items-center">
@@ -417,7 +397,6 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
   if (phase === "results") {
     return (
       <div className="flex flex-col items-center justify-center py-16">
-        <ChallengeHeader current={quizQuestions.length} total={quizQuestions.length} score={score} />
         <Card className="w-full max-w-md text-center border shadow-md">
           <CardHeader>
             <Trophy className="w-16 h-16 mx-auto text-yellow-400 mb-4" />

--- a/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
+++ b/src/components/games/FlashcardMemoryGame/MemoryChallenge.tsx
@@ -3,7 +3,49 @@ import { Card, CardHeader, CardContent } from "../../ui/card";
 import { Button } from "../../ui/button";
 import { Progress } from "../../ui/progress";
 import { Badge } from "../../ui/badge";
-import { Play, RotateCcw, Trophy, Timer } from "lucide-react";
+import {
+  Play,
+  RotateCcw,
+  Trophy,
+  Timer,
+  ArrowLeft,
+  ArrowRight,
+  Target,
+  Star,
+} from "lucide-react";
+
+const ChallengeHeader: React.FC<{
+  current: number;
+  total: number;
+  score: number;
+  timer?: number;
+}> = ({ current, total, score, timer }) => (
+  <div className="flex flex-wrap items-center justify-between mb-6 gap-4">
+    <div className="flex items-center gap-3">
+      <span className="font-bold text-xl tracking-wide bg-gradient-to-r from-purple-400 to-pink-600 bg-clip-text text-transparent">
+        Memory Challenge
+      </span>
+      <span className="flex items-center gap-1 px-3 py-1 rounded-full bg-purple-900/50 border border-purple-700">
+        <Target className="w-4 h-4 text-purple-400" />
+        <span className="font-semibold text-purple-200">
+          Card: {current}/{total}
+        </span>
+      </span>
+      <span className="flex items-center gap-1 px-3 py-1 rounded-full bg-yellow-900/40 border border-yellow-600">
+        <Star className="w-4 h-4 text-yellow-300" />
+        <span className="font-semibold text-yellow-200">Score: {score}</span>
+      </span>
+      {typeof timer === "number" && (
+        <span className="flex items-center gap-1 px-4 py-1 rounded-full bg-blue-900/50 shadow-inner border border-blue-600">
+          <Timer className="w-5 h-5 text-blue-400" />
+          <span className="font-mono text-lg tracking-widest text-blue-200">
+            {timer}s
+          </span>
+        </span>
+      )}
+    </div>
+  </div>
+);
 
 interface FlashcardData {
   id: string;
@@ -121,6 +163,31 @@ const MemoryChallenge: React.FC<MemoryChallengeProps> = ({ flashcards = [] }) =>
   }, [phase, quizIndex, quizQuestions.length]);
 
   useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (phase === "show") {
+        if (e.key === "ArrowRight") {
+          e.preventDefault();
+          nextShow();
+        } else if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          prevShow();
+        }
+      } else if (phase === "quiz") {
+        if (e.key === "ArrowRight") {
+          e.preventDefault();
+          nextQuiz();
+        } else if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          prevQuiz();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [phase, showIndex, quizIndex]);
+
+  useEffect(() => {
     if (phase === "quiz" && timer <= 0) {
       handleAnswer(null);
     }
@@ -160,6 +227,34 @@ const MemoryChallenge: React.FC<MemoryChallengeProps> = ({ flashcards = [] }) =>
     }
   };
 
+  const prevQuiz = () => {
+    if (quizIndex > 0) {
+      setQuizIndex((i) => i - 1);
+      setTimer(QUIZ_TIME_LIMIT);
+    }
+  };
+
+  const nextQuiz = () => {
+    if (quizIndex < quizQuestions.length - 1) {
+      setQuizIndex((i) => i + 1);
+      setTimer(QUIZ_TIME_LIMIT);
+    }
+  };
+
+  const prevShow = () => {
+    if (showIndex > 0) {
+      setShowIndex((i) => i - 1);
+    }
+  };
+
+  const nextShow = () => {
+    if (showIndex < CHALLENGE_LENGTH - 1) {
+      setShowIndex((i) => i + 1);
+    } else {
+      setPhase("quiz");
+    }
+  };
+
   const restart = () => {
     setPhase("show");
     setShowIndex(0);
@@ -187,6 +282,7 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
     const card = flashcards[showIndex];
     return (
       <div className="flex flex-col items-center justify-center py-12">
+        <ChallengeHeader current={showIndex + 1} total={CHALLENGE_LENGTH} score={score} />
         <Card className="w-full max-w-xl text-center border shadow-md">
           <CardHeader>
             <div className="flex justify-between items-center">
@@ -222,15 +318,34 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
             </div>
           </CardContent>
         </Card>
+        <div className="flex justify-between w-full max-w-xl mt-4">
+          <Button onClick={prevShow} variant="outline" disabled={showIndex === 0}>
+            <ArrowLeft className="w-4 h-4 mr-2" /> Prev
+          </Button>
+          <Button onClick={nextShow}>
+            Next <ArrowRight className="w-4 h-4 ml-2" />
+          </Button>
+        </div>
       </div>
     );
   }
 
   // PHASE 2: Quiz
   if (phase === "quiz") {
+    if (quizQuestions.length === 0) {
+      return (
+        <div className="text-center py-10 text-lg">Preparing questions...</div>
+      );
+    }
     const q = quizQuestions[quizIndex];
     return (
       <div className="flex flex-col items-center justify-center py-12">
+        <ChallengeHeader
+          current={quizIndex + 1}
+          total={quizQuestions.length}
+          score={score}
+          timer={timer}
+        />
         <Card className="w-full max-w-xl text-center border shadow-md">
           <CardHeader>
             <div className="flex justify-between items-center">
@@ -286,6 +401,14 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
             </div>
           </CardContent>
         </Card>
+        <div className="flex justify-between w-full max-w-xl mt-4">
+          <Button onClick={prevQuiz} variant="outline" disabled={quizIndex === 0}>
+            <ArrowLeft className="w-4 h-4 mr-2" /> Prev
+          </Button>
+          <Button onClick={nextQuiz} disabled={quizIndex === quizQuestions.length - 1}>
+            Next <ArrowRight className="w-4 h-4 ml-2" />
+          </Button>
+        </div>
       </div>
     );
   }
@@ -294,6 +417,7 @@ if (!flashcards || flashcards.length < CHALLENGE_LENGTH) {
   if (phase === "results") {
     return (
       <div className="flex flex-col items-center justify-center py-16">
+        <ChallengeHeader current={quizQuestions.length} total={quizQuestions.length} score={score} />
         <Card className="w-full max-w-md text-center border shadow-md">
           <CardHeader>
             <Trophy className="w-16 h-16 mx-auto text-yellow-400 mb-4" />


### PR DESCRIPTION
## Summary
- ensure Memory Challenge waits for quiz questions
- add header and navigation controls with keyboard shortcuts for Memory Challenge

## Testing
- `npm run build`
- `npm test` *(fails: `ReferenceError: require is not defined in ES module scope`)*
- `npm run lint` *(fails: `ReferenceError: require is not defined in ES module scope`)*

------
https://chatgpt.com/codex/tasks/task_e_6855e17929a083309f7541af8564d963