### PR TITLE
Add basic frontend page tests

### DIFF
--- a/INTEGRATION_SETUP.md
+++ b/INTEGRATION_SETUP.md
@@ -1,0 +1,19 @@
+# Integration Test Database Setup
+
+These frontend tests mock API requests by default. To run the application against a real backend database instead, follow these steps:
+
+1. Install MySQL and create a database named `learning_english_app_test`.
+2. Import the SQL scripts from the `SQLScripts/` directory to populate schema and seed data.
+   ```bash
+   mysql -u root -p learning_english_app_test < SQLScripts/schema.sql
+   mysql -u root -p learning_english_app_test < SQLScripts/core.data.sql
+   # ... import other *.sql files as needed
+   ```
+3. Copy `.env.test` to `.env.development` and update the MySQL credentials if necessary.
+4. Start the backend API:
+   ```bash
+   npm run dev:server
+   ```
+5. Run the frontend dev server or tests normally.
+
+The mocked fetch logic will be bypassed when the application is executed in a real browser pointing at your running API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
         "@vitejs/plugin-react": "^4.3.1",
+        "@vitest/coverage-v8": "^1.6.1",
         "autoprefixer": "^10.4.20",
         "chai": "^4.3.10",
         "eslint": "^9.9.0",
@@ -409,6 +410,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3641,6 +3649,49 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8736,6 +8787,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.20",
     "chai": "^4.3.10",
     "eslint": "^9.9.0",

--- a/src/__tests__/AboutPage.test.tsx
+++ b/src/__tests__/AboutPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import AboutPage from '../pages/AboutPage';
+import { renderWithProviders } from './test-utils';
+
+describe('AboutPage', () => {
+  it('renders about heading', () => {
+    renderWithProviders(<AboutPage />);
+    expect(screen.getByText('About IELTS Master')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/AuthModal.test.tsx
+++ b/src/__tests__/AuthModal.test.tsx
@@ -1,0 +1,24 @@
+import { screen, fireEvent } from '@testing-library/react';
+import AuthModal from '../components/auth/AuthModal';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('AuthModal', () => {
+  it('renders login view when open', () => {
+    renderWithProviders(<AuthModal />, {
+      auth: { isAuthModalOpen: true, authModalView: 'login' }
+    });
+    expect(screen.getByText('Sign in to your account')).toBeInTheDocument();
+  });
+
+  it('closes when clicking overlay', () => {
+    const close = vi.fn();
+    renderWithProviders(<AuthModal />, {
+      auth: { isAuthModalOpen: true, authModalView: 'login', closeAuthModal: close }
+    });
+    const overlay = document.querySelector('div.fixed');
+    if (!overlay) throw new Error('overlay not found');
+    fireEvent.click(overlay);
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/Categories.test.tsx
+++ b/src/__tests__/Categories.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+import Categories from '../components/home/Categories';
+import { renderWithProviders } from './test-utils';
+
+describe('Categories', () => {
+  it('renders category links', () => {
+    renderWithProviders(
+      <Routes>
+        <Route path="/" element={<Categories />} />
+      </Routes>
+    );
+    expect(screen.getByText('Listening Tests')).toBeInTheDocument();
+    expect(screen.getByText('Vocabulary Games')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/CoursesPage.test.tsx
+++ b/src/__tests__/CoursesPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import CoursesPage from '../pages/CoursesPage';
+import { renderWithProviders } from './test-utils';
+
+describe('CoursesPage', () => {
+  it('renders courses heading', () => {
+    renderWithProviders(<CoursesPage />);
+    expect(screen.getByText('IELTS Courses')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/CoursesPage.test.tsx
+++ b/src/__tests__/CoursesPage.test.tsx
@@ -1,10 +1,13 @@
 import { screen } from '@testing-library/react';
 import CoursesPage from '../pages/CoursesPage';
-import { renderWithProviders } from './test-utils';
+import { renderWithProviders, mockApi } from './test-utils';
 
 describe('CoursesPage', () => {
-  it('renders courses heading', () => {
+  it('loads and displays courses', async () => {
+    const restore = mockApi();
     renderWithProviders(<CoursesPage />);
     expect(screen.getByText('IELTS Courses')).toBeInTheDocument();
+    expect(await screen.findByText('Sample Course')).toBeInTheDocument();
+    restore();
   });
 });

--- a/src/__tests__/EnhancedQuizResults.test.tsx
+++ b/src/__tests__/EnhancedQuizResults.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EnhancedQuizResults from '../components/quiz/EnhancedQuizResults';
+import { renderWithProviders } from './test-utils';
+
+const sampleQuestions = [
+  { question_id: '1', question: 'Q1', type_id: 1, content: [{ choice_id: 'a', choice_text: 'A' }] },
+];
+const sampleResult = {
+  accuracy: 95,
+  detailedAnswers: [
+    {
+      answers: [{ user_answer: 1, marked: true, choice_id: 'a', is_correct_choice: true }],
+    },
+  ],
+};
+
+describe('EnhancedQuizResults', () => {
+  it('renders grade label and calls callbacks', async () => {
+    const user = userEvent.setup();
+    const retry = vi.fn();
+    renderWithProviders(
+      <EnhancedQuizResults questions={sampleQuestions} result={sampleResult} onRetry={retry} />
+    );
+    expect(screen.getByText('Excellent')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(retry).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/Features.test.tsx
+++ b/src/__tests__/Features.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/react';
+import Features from '../components/home/Features';
+import { renderWithProviders } from './test-utils';
+
+describe('Features', () => {
+  it('lists key features', () => {
+    renderWithProviders(<Features />);
+    expect(screen.getByText('Why Choose IELTS Master?')).toBeInTheDocument();
+    expect(screen.getByText('Authentic Practice Tests')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/FeedbackModal.test.tsx
+++ b/src/__tests__/FeedbackModal.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeedbackModal from '../components/games/word-association/FeedbackModal';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('FeedbackModal', () => {
+  const round = {
+    relationType: 'synonym',
+    relatedWords: ['fast'],
+    targetMeaning: 'quick',
+    synonyms: ['fast'],
+    antonyms: [],
+    guidewords: []
+  } as any;
+
+  it('renders feedback message and calls close on overlay', async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    renderWithProviders(
+      <FeedbackModal feedback="Perfect" currentRound={round} selectedWords={['fast']} closeFeedback={close} />
+    );
+    expect(screen.getByText('Perfect')).toBeInTheDocument();
+    await user.click(screen.getByText('Perfect'));
+    expect(close).not.toHaveBeenCalled();
+    const overlay = screen
+      .getByText('Perfect')
+      .parentElement!.parentElement!.parentElement!;
+    await user.click(overlay);
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/FlashcardsPage.test.tsx
+++ b/src/__tests__/FlashcardsPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import FlashcardsPage from '../pages/FlashcardsPage';
+import { renderWithProviders } from './test-utils';
+
+describe('FlashcardsPage', () => {
+  it('renders flashcards heading', () => {
+    renderWithProviders(<FlashcardsPage />);
+    expect(screen.getByText('Flashcards')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Footer.test.tsx
+++ b/src/__tests__/Footer.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/react';
+import Footer from '../components/layout/Footer';
+import { renderWithProviders } from './test-utils';
+
+describe('Footer', () => {
+  it('renders footer content', () => {
+    renderWithProviders(<Footer />);
+    expect(screen.getByText('IELTS Master')).toBeInTheDocument();
+    expect(screen.getByText(/© 2024 IELTS Master/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/FullMockTestsPage.test.tsx
+++ b/src/__tests__/FullMockTestsPage.test.tsx
@@ -1,10 +1,13 @@
 import { screen } from '@testing-library/react';
 import FullMockTestsPage from '../pages/FullMockTestsPage';
-import { renderWithProviders } from './test-utils';
+import { renderWithProviders, mockApi } from './test-utils';
 
 describe('FullMockTestsPage', () => {
-  it('shows mock tests heading', () => {
+  it('fetches mock tests and displays them', async () => {
+    const restore = mockApi();
     renderWithProviders(<FullMockTestsPage />);
     expect(screen.getByText('Full IELTS Mock Tests')).toBeInTheDocument();
+    expect(await screen.findByText('Mock Test')).toBeInTheDocument();
+    restore();
   });
 });

--- a/src/__tests__/FullMockTestsPage.test.tsx
+++ b/src/__tests__/FullMockTestsPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import FullMockTestsPage from '../pages/FullMockTestsPage';
+import { renderWithProviders } from './test-utils';
+
+describe('FullMockTestsPage', () => {
+  it('shows mock tests heading', () => {
+    renderWithProviders(<FullMockTestsPage />);
+    expect(screen.getByText('Full IELTS Mock Tests')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/GameCompletion.test.tsx
+++ b/src/__tests__/GameCompletion.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameCompletion from '../components/games/FlashcardMemoryGame/GameCompletion';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+const sampleCard = {
+  id: '1',
+  word: 'hello',
+  definition: 'hi',
+  example: 'hello world',
+  difficulty: 'easy',
+  category: 'greet',
+  memorized: false,
+  attempts: 0,
+  correctStreak: 0,
+};
+
+const baseProps = {
+  score: 20,
+  accuracy: 80,
+  memorizedCount: 5,
+  time: '1m',
+  correctWords: [sampleCard],
+  incorrectWords: [],
+  missedWords: [],
+  onPlayAgain: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe('GameCompletion', () => {
+  it('renders stats and handles play again', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GameCompletion {...baseProps} />);
+    expect(screen.getByText('Session Complete! ⚡')).toBeInTheDocument();
+    expect(screen.getByText('Score')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Play Again' }));
+    expect(baseProps.onPlayAgain).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/GameHeader.test.tsx
+++ b/src/__tests__/GameHeader.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameHeader from '../components/games/FlashcardMemoryGame/GameHeader';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+const baseProps = {
+  gameMode: 'quiz',
+  timer: 55,
+  currentIndex: 2,
+  totalCards: 5,
+  score: 10,
+  isPaused: false,
+  onPauseToggle: vi.fn(),
+  onShuffle: vi.fn(),
+  onReset: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe('GameHeader', () => {
+  it('displays timer and card progress', () => {
+    renderWithProviders(<GameHeader {...baseProps} />);
+    expect(screen.getByText('quiz Mode')).toBeInTheDocument();
+    expect(screen.getByText('Card: 2/5')).toBeInTheDocument();
+    expect(screen.getByText('Score: 10')).toBeInTheDocument();
+  });
+
+  it('calls callbacks when clicking buttons', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GameHeader {...baseProps} />);
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    await user.click(buttons[1]);
+    await user.click(buttons[2]);
+    await user.click(buttons[3]);
+    expect(baseProps.onPauseToggle).toHaveBeenCalled();
+    expect(baseProps.onShuffle).toHaveBeenCalled();
+    expect(baseProps.onReset).toHaveBeenCalled();
+    expect(baseProps.onBack).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/GameSetup.test.tsx
+++ b/src/__tests__/GameSetup.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameSetup from '../components/games/FlashcardMemoryGame/GameSetup';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+const baseProps = {
+  lexiconType: 'vocabulary',
+  setLexiconType: vi.fn(),
+  gameMode: 'study',
+  setGameMode: vi.fn(),
+  selectedDifficulty: 'easy',
+  setSelectedDifficulty: vi.fn(),
+  onStart: vi.fn(),
+  onBack: vi.fn(),
+};
+
+describe('GameSetup', () => {
+  it('calls setter when selecting word type', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GameSetup {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: 'Idioms' }));
+    expect(baseProps.setLexiconType).toHaveBeenCalledWith('idiom');
+  });
+
+  it('starts game on start button click', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GameSetup {...baseProps} />);
+    await user.click(screen.getByRole('button', { name: 'Start Flashcard Game' }));
+    expect(baseProps.onStart).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/GapFillingQuestion.test.tsx
+++ b/src/__tests__/GapFillingQuestion.test.tsx
@@ -1,0 +1,24 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GapFillingQuestion from '../components/quiz/GapFillingQuestion';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('GapFillingQuestion', () => {
+  const question = {
+    question_id: 1,
+    question: 'Fill the gaps',
+    content: [{ sequence_id: 1 }, { sequence_id: 2 }]
+  } as any;
+
+  it('calls onAnswer when typing', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    renderWithProviders(
+      <GapFillingQuestion question={question} answers={{}} onAnswer={onAnswer} />
+    );
+    const input = screen.getByPlaceholderText('Blank 1');
+    await user.type(input, 'a');
+    expect(onAnswer).toHaveBeenLastCalledWith(1, 'a');
+  });
+});

--- a/src/__tests__/ListeningTestPage.test.tsx
+++ b/src/__tests__/ListeningTestPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import ListeningTestPage from '../pages/ListeningTestPage';
+import { renderWithProviders } from './test-utils';
+
+describe('ListeningTestPage', () => {
+  it('renders listening instructions', () => {
+    renderWithProviders(<ListeningTestPage />);
+    expect(screen.getByText('IELTS Listening Test')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Login.test.tsx
+++ b/src/__tests__/Login.test.tsx
@@ -1,0 +1,26 @@
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Login from '../components/auth/Login';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('Login component', () => {
+  it('shows error if fields empty', async () => {
+    const user = userEvent.setup();
+    const loginFn = vi.fn();
+    renderWithProviders(<Login switchToRegister={() => {}} />, { auth: { login: loginFn } });
+    fireEvent.submit(document.querySelector('form')!);
+    expect(loginFn).not.toHaveBeenCalled();
+    expect(await screen.findByText('Please fill in all fields')).toBeInTheDocument();
+  });
+
+  it('calls login with entered credentials', async () => {
+    const user = userEvent.setup();
+    const loginFn = vi.fn().mockResolvedValue({ success: true });
+    renderWithProviders(<Login switchToRegister={() => {}} />, { auth: { login: loginFn } });
+    await user.type(screen.getByLabelText('Email'), 'john@example.com');
+    await user.type(screen.getByLabelText('Password'), 'pass12345');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(loginFn).toHaveBeenCalledWith('john@example.com', 'pass12345');
+  });
+});

--- a/src/__tests__/LoginModal.test.tsx
+++ b/src/__tests__/LoginModal.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginModal from '../components/auth/LoginModal';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('LoginModal', () => {
+  it('renders when open and closes on button click', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithProviders(
+      <LoginModal isOpen onClose={onClose} onSwitchToRegister={() => {}} />
+    );
+    expect(screen.getByText('Welcome Back')).toBeInTheDocument();
+    await user.click(screen.getByText('×'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/MultipleChoiceQuestion.test.tsx
+++ b/src/__tests__/MultipleChoiceQuestion.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MultipleChoiceQuestion from '../components/quiz/MultipleChoiceQuestion';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('MultipleChoiceQuestion', () => {
+  const question = {
+    question_id: 1,
+    question: 'Select the correct option',
+    content: [
+      { choice_id: 1, choice_text: 'A' },
+      { choice_id: 2, choice_text: 'B' }
+    ]
+  } as any;
+
+  it('calls onAnswer when selecting a choice', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
+    renderWithProviders(
+      <MultipleChoiceQuestion question={question} onAnswer={onAnswer} />
+    );
+    await user.click(screen.getByLabelText('B'));
+    expect(onAnswer).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/__tests__/Navbar.test.tsx
+++ b/src/__tests__/Navbar.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Navbar from '../components/layout/Navbar';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('Navbar', () => {
+  it('shows login options when logged out', () => {
+    const toggle = vi.fn();
+    renderWithProviders(<Navbar theme="light" toggleTheme={toggle} />);
+    expect(screen.getByText('Log In')).toBeInTheDocument();
+    expect(screen.getByText('Sign Up')).toBeInTheDocument();
+  });
+
+  it('shows user greeting when logged in', () => {
+    const toggle = vi.fn();
+    renderWithProviders(<Navbar theme="light" toggleTheme={toggle} />, {
+      auth: { user: { firstName: 'John' }, isAuthenticated: true }
+    });
+    expect(screen.getByText('Hello, John')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('calls toggleTheme when clicking button', async () => {
+    const user = userEvent.setup();
+    const toggle = vi.fn();
+    renderWithProviders(<Navbar theme="dark" toggleTheme={toggle} />);
+    await user.click(screen.getByLabelText('Switch to light mode'));
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/PageTransition.test.tsx
+++ b/src/__tests__/PageTransition.test.tsx
@@ -1,0 +1,14 @@
+import { screen } from '@testing-library/react';
+import PageTransition from '../components/layout/PageTransition';
+import { renderWithProviders } from './test-utils';
+
+describe('PageTransition', () => {
+  it('renders its children', () => {
+    renderWithProviders(
+      <PageTransition>
+        <div>Inner Content</div>
+      </PageTransition>
+    );
+    expect(screen.getByText('Inner Content')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/PauseOverlay.test.tsx
+++ b/src/__tests__/PauseOverlay.test.tsx
@@ -1,0 +1,16 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PauseOverlay from '../components/games/word-association/PauseOverlay';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('PauseOverlay', () => {
+  it('shows overlay when paused and resumes on click', async () => {
+    const user = userEvent.setup();
+    const toggle = vi.fn();
+    renderWithProviders(<PauseOverlay isPaused togglePause={toggle} />);
+    expect(screen.getByText('Game Paused')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /resume game/i }));
+    expect(toggle).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/PracticePage.test.tsx
+++ b/src/__tests__/PracticePage.test.tsx
@@ -1,10 +1,22 @@
 import { screen } from '@testing-library/react';
 import PracticePage from '../pages/PracticePage';
-import { renderWithProviders } from './test-utils';
+import { renderWithProviders, mockApi } from './test-utils';
+
+const API_URL = 'http://localhost:3000/api/';
 
 describe('PracticePage', () => {
-  it('renders error message when loading fails', () => {
+  it('shows error message when API fails', async () => {
+    const restore = mockApi();
+    // override start quiz endpoint with failure
+    (global.fetch as any).mockImplementationOnce(async (url: string) => {
+      if (url.startsWith(`${API_URL}quizzes/start/`)) {
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      return Promise.reject(new Error('Unhandled request'));
+    });
+
     renderWithProviders(<PracticePage />);
-    expect(screen.getByText('Unable to Load Quiz')).toBeInTheDocument();
+    expect(await screen.findByText('Unable to Load Quiz')).toBeInTheDocument();
+    restore();
   });
 });

--- a/src/__tests__/PracticePage.test.tsx
+++ b/src/__tests__/PracticePage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import PracticePage from '../pages/PracticePage';
+import { renderWithProviders } from './test-utils';
+
+describe('PracticePage', () => {
+  it('renders error message when loading fails', () => {
+    renderWithProviders(<PracticePage />);
+    expect(screen.getByText('Unable to Load Quiz')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/PracticeTestsPage.test.tsx
+++ b/src/__tests__/PracticeTestsPage.test.tsx
@@ -1,10 +1,13 @@
 import { screen } from '@testing-library/react';
 import PracticeTestsPage from '../pages/PracticeTestsPage';
-import { renderWithProviders } from './test-utils';
+import { renderWithProviders, mockApi } from './test-utils';
 
 describe('PracticeTestsPage', () => {
-  it('renders main heading', () => {
+  it('loads quizzes from API', async () => {
+    const restore = mockApi();
     renderWithProviders(<PracticeTestsPage />);
     expect(screen.getByText('Practice Tests')).toBeInTheDocument();
+    expect(await screen.findByText('Mock Quiz')).toBeInTheDocument();
+    restore();
   });
 });

--- a/src/__tests__/PracticeTestsPage.test.tsx
+++ b/src/__tests__/PracticeTestsPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import PracticeTestsPage from '../pages/PracticeTestsPage';
+import { renderWithProviders } from './test-utils';
+
+describe('PracticeTestsPage', () => {
+  it('renders main heading', () => {
+    renderWithProviders(<PracticeTestsPage />);
+    expect(screen.getByText('Practice Tests')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Progress.test.tsx
+++ b/src/__tests__/Progress.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/react';
+import { Progress } from '../components/ui/progress';
+import { renderWithProviders } from './test-utils';
+
+describe('Progress', () => {
+  it('renders progress bar', () => {
+    renderWithProviders(<Progress value={40} data-testid="progress" />);
+    const bar = screen.getByTestId('progress').firstChild as HTMLElement;
+    expect(bar).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/QuizList.test.tsx
+++ b/src/__tests__/QuizList.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuizList from '../components/home/QuizList';
+import { renderWithProviders, mockApi } from './test-utils';
+import { vi } from 'vitest';
+
+describe('QuizList', () => {
+  it('fetches and displays quizzes', async () => {
+    const restore = mockApi();
+    renderWithProviders(<QuizList />);
+    expect(await screen.findByText('Sample Quiz')).toBeInTheDocument();
+    restore();
+  });
+
+  it('opens auth modal when not logged in', async () => {
+    const user = userEvent.setup();
+    const restore = mockApi();
+    const open = vi.fn();
+    renderWithProviders(<QuizList />, { auth: { openAuthModal: open } });
+    await screen.findByText('Sample Quiz');
+    await user.click(screen.getByRole('button', { name: /start quiz/i }));
+    expect(open).toHaveBeenCalledWith('login');
+    restore();
+  });
+});

--- a/src/__tests__/QuizResults.test.tsx
+++ b/src/__tests__/QuizResults.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import QuizResults from '../components/quiz/QuizResults';
+import { renderWithProviders } from './test-utils';
+
+const questions = [
+  {
+    question_id: 'q1',
+    question: 'Sample question?',
+    type_id: 1,
+    content: [
+      { choice_id: 1, choice_text: 'Yes' },
+      { choice_id: 2, choice_text: 'No' },
+    ],
+  },
+];
+
+const result = {
+  accuracy: 100,
+  detailedAnswers: [
+    {
+      answers: [
+        { choice_id: 1, user_answer: 1, is_correct_choice: true, marked: true },
+      ],
+    },
+  ],
+};
+
+describe('QuizResults', () => {
+  it('shows score and correctness label', () => {
+    renderWithProviders(
+      <QuizResults questions={questions} result={result} />
+    );
+    expect(screen.getByText('Score: 100%')).toBeInTheDocument();
+    expect(screen.getByText('Correct')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Register.test.tsx
+++ b/src/__tests__/Register.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Register from '../components/auth/Register';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('Register component', () => {
+  it('shows validation error for password mismatch', async () => {
+    const user = userEvent.setup();
+    const registerFn = vi.fn();
+    renderWithProviders(<Register switchToLogin={() => {}} />, { auth: { register: registerFn } });
+    await user.type(screen.getByLabelText('First Name'), 'John');
+    await user.type(screen.getByLabelText('Last Name'), 'Doe');
+    await user.type(screen.getByLabelText('Email'), 'john@example.com');
+    await user.type(screen.getByLabelText('Password'), 'pass12345');
+    await user.type(screen.getByLabelText('Confirm Password'), 'wrong');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+    expect(registerFn).not.toHaveBeenCalled();
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+  });
+
+  it('calls register with form data', async () => {
+    const user = userEvent.setup();
+    const registerFn = vi.fn().mockResolvedValue({ success: true });
+    renderWithProviders(<Register switchToLogin={() => {}} />, { auth: { register: registerFn } });
+    await user.type(screen.getByLabelText('First Name'), 'Jane');
+    await user.type(screen.getByLabelText('Last Name'), 'Smith');
+    await user.type(screen.getByLabelText('Email'), 'jane@example.com');
+    await user.type(screen.getByLabelText('Password'), 'password123');
+    await user.type(screen.getByLabelText('Confirm Password'), 'password123');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+    expect(registerFn).toHaveBeenCalledWith({
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane@example.com',
+      password: 'password123'
+    });
+  });
+});

--- a/src/__tests__/SetupScreen.test.tsx
+++ b/src/__tests__/SetupScreen.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SetupScreen from '../components/games/word-association/SetupScreen';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('SetupScreen', () => {
+  it('renders mode buttons and calls setMode', async () => {
+    const user = userEvent.setup();
+    const setMode = vi.fn();
+    renderWithProviders(
+      <SetupScreen mode="vocabulary" setMode={setMode} startGame={() => {}} noWordsAvailable={false} onBack={() => {}} />
+    );
+    await user.click(screen.getByText('Idioms'));
+    expect(setMode).toHaveBeenCalledWith('idiom');
+  });
+
+  it('calls startGame when selecting a level', async () => {
+    const user = userEvent.setup();
+    const startGame = vi.fn();
+    renderWithProviders(
+      <SetupScreen mode="vocabulary" setMode={() => {}} startGame={startGame} noWordsAvailable={false} onBack={() => {}} />
+    );
+    await user.click(screen.getByText(/easy/i));
+    expect(startGame).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/SpeakingPracticePage.test.tsx
+++ b/src/__tests__/SpeakingPracticePage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import SpeakingPracticePage from '../pages/SpeakingPracticePage';
+import { renderWithProviders } from './test-utils';
+
+describe('SpeakingPracticePage', () => {
+  it('renders speaking practice heading', () => {
+    renderWithProviders(<SpeakingPracticePage />);
+    expect(screen.getByText('IELTS Speaking Practice')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Statistics.test.tsx
+++ b/src/__tests__/Statistics.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/react';
+import Statistics from '../components/home/Statistics';
+import { renderWithProviders } from './test-utils';
+
+describe('Statistics', () => {
+  it('displays key stats', () => {
+    renderWithProviders(<Statistics />);
+    expect(screen.getByText('Students Worldwide')).toBeInTheDocument();
+    expect(screen.getByText('50,000+')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/StudyPlansPage.test.tsx
+++ b/src/__tests__/StudyPlansPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import StudyPlansPage from '../pages/StudyPlansPage';
+import { renderWithProviders } from './test-utils';
+
+describe('StudyPlansPage', () => {
+  it('renders study plans heading', () => {
+    renderWithProviders(<StudyPlansPage />);
+    expect(screen.getByText('IELTS Study Plans')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/TemplatesPage.test.tsx
+++ b/src/__tests__/TemplatesPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import TemplatesPage from '../pages/TemplatesPage';
+import { renderWithProviders } from './test-utils';
+
+describe('TemplatesPage', () => {
+  it('renders practice quiz heading', () => {
+    renderWithProviders(<TemplatesPage />);
+    expect(screen.getByText('IELTS Practice Quiz')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Testimonials.test.tsx
+++ b/src/__tests__/Testimonials.test.tsx
@@ -1,0 +1,11 @@
+import { screen } from '@testing-library/react';
+import Testimonials from '../components/home/Testimonials';
+import { renderWithProviders } from './test-utils';
+
+describe('Testimonials', () => {
+  it('shows student testimonials', () => {
+    renderWithProviders(<Testimonials />);
+    expect(screen.getByText('What Our Students Say')).toBeInTheDocument();
+    expect(screen.getByText('Sarah Chen')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/VocabularyBuilderPage.test.tsx
+++ b/src/__tests__/VocabularyBuilderPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import VocabularyBuilderPage from '../pages/VocabularyBuilderPage';
+import { renderWithProviders } from './test-utils';
+
+describe('VocabularyBuilderPage', () => {
+  it('renders vocabulary builder heading', () => {
+    renderWithProviders(<VocabularyBuilderPage />);
+    expect(screen.getByText('Vocabulary Builder')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/VocabularyGames.test.tsx
+++ b/src/__tests__/VocabularyGames.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VocabularyGames from '../components/games/VocabularyGames';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+vi.mock('../components/games/MatchingCardsGame/index', () => ({ default: () => <div>Matching Game</div> }));
+vi.mock('../components/games/WordAssociationGame', () => ({ default: () => <div>Word Association</div> }));
+vi.mock('../components/games/FlashcardMemoryGame/FlashcardMemoryGame', () => ({ default: () => <div>Flashcard Game</div> }));
+
+describe('VocabularyGames', () => {
+  it('renders game list and opens a game', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<VocabularyGames />);
+    expect(screen.getByText('Vocabulary Games')).toBeInTheDocument();
+    await user.click(screen.getAllByRole('button', { name: /play game/i })[0]);
+    expect(screen.getByText('Back to Games')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/WordAssociationCompletion.test.tsx
+++ b/src/__tests__/WordAssociationCompletion.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CompletionScreen from '../components/games/word-association/CompletionScreen';
+import { renderWithProviders } from './test-utils';
+import { vi } from 'vitest';
+
+describe('WordAssociation CompletionScreen', () => {
+  it('shows stats and triggers callbacks', async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    const back = vi.fn();
+    renderWithProviders(
+      <CompletionScreen totalRounds={5} score={100} accuracy={80} correctAnswers={4} totalTime={90} resetGame={reset} onBack={back} />
+    );
+    expect(screen.getByText(/Game Complete!/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /play again/i }));
+    expect(reset).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /back to games/i }));
+    expect(back).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/WritingTestPage.test.tsx
+++ b/src/__tests__/WritingTestPage.test.tsx
@@ -1,0 +1,10 @@
+import { screen } from '@testing-library/react';
+import WritingTestPage from '../pages/WritingTestPage';
+import { renderWithProviders } from './test-utils';
+
+describe('WritingTestPage', () => {
+  it('renders writing test heading', () => {
+    renderWithProviders(<WritingTestPage />);
+    expect(screen.getByText('IELTS Writing Test')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/test-utils.tsx
+++ b/src/__tests__/test-utils.tsx
@@ -31,10 +31,13 @@ export function mockApi() {
   return () => { global.fetch = original; };
 }
 
-type Options = { route?: string };
+type Options = { route?: string; auth?: Partial<any> };
 
-export function renderWithProviders(ui: React.ReactElement, options: Options = {}) {
-  const { route = '/' } = options;
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options: Options = {}
+) {
+  const { route = '/', auth = {} } = options;
   const mockAuth = {
     user: null,
     isLoading: false,
@@ -47,6 +50,7 @@ export function renderWithProviders(ui: React.ReactElement, options: Options = {
     openAuthModal: vi.fn(),
     closeAuthModal: vi.fn(),
     setAuthModalView: vi.fn(),
+    ...auth,
   } as any;
 
   window.history.pushState({}, '', route);

--- a/src/__tests__/test-utils.tsx
+++ b/src/__tests__/test-utils.tsx
@@ -18,6 +18,30 @@ export function mockApi() {
         response: [{ quiz_id: '1', title: 'Mock Quiz', skill_id: 1, skill_description: 'Listening', time_allowed: 60, attempts: 0, number_of_questions: 5, average_rating: 4, rating_count: 1, favorite: false }]
       }), { status: 200 }));
     }
+    if (url.endsWith('/home') || url.endsWith('home')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            statusCode: 200,
+            response: [
+              {
+                quiz_id: 1,
+                title: 'Sample Quiz',
+                skill_description: 'Reading',
+                description: 'desc',
+                time_allowed: 45,
+                attempts: 2,
+                number_of_questions: 10,
+                average_rating: 4,
+                rating_count: 1,
+                favorite: 0,
+              },
+            ],
+          }),
+          { status: 200 }
+        )
+      );
+    }
     if (url.endsWith('/mock-tests')) {
       return Promise.resolve(new Response(JSON.stringify({
         response: [{ MockTestId: 1, Title: 'Mock Test', Description: 'desc', TotalDuration: 120, MockTestSection: [] }]

--- a/src/__tests__/test-utils.tsx
+++ b/src/__tests__/test-utils.tsx
@@ -4,9 +4,34 @@ import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
 
-type Options = {
-  route?: string;
-};
+export function mockApi() {
+  const original = global.fetch;
+  global.fetch = vi.fn(async (input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/courses')) {
+      return Promise.resolve(new Response(JSON.stringify({
+        response: [{ CourseId: 1, Title: 'Sample Course' }]
+      }), { status: 200 }));
+    }
+    if (url.endsWith('/quizzes')) {
+      return Promise.resolve(new Response(JSON.stringify({
+        response: [{ quiz_id: '1', title: 'Mock Quiz', skill_id: 1, skill_description: 'Listening', time_allowed: 60, attempts: 0, number_of_questions: 5, average_rating: 4, rating_count: 1, favorite: false }]
+      }), { status: 200 }));
+    }
+    if (url.endsWith('/mock-tests')) {
+      return Promise.resolve(new Response(JSON.stringify({
+        response: [{ MockTestId: 1, Title: 'Mock Test', Description: 'desc', TotalDuration: 120, MockTestSection: [] }]
+      }), { status: 200 }));
+    }
+    if (url.includes('/quizzes/start/')) {
+      return Promise.resolve(new Response(JSON.stringify({ statusCode: 200, response: { questions: [], parts: [], attempt_id: 1, expired_time: '2030-01-01' } }), { status: 200 }));
+    }
+    return Promise.reject(new Error('Unhandled request: ' + url));
+  });
+  return () => { global.fetch = original; };
+}
+
+type Options = { route?: string };
 
 export function renderWithProviders(ui: React.ReactElement, options: Options = {}) {
   const { route = '/' } = options;

--- a/src/__tests__/useAuth.test.tsx
+++ b/src/__tests__/useAuth.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { useAuth } from '../hooks/useAuth'
+import { AuthContext } from '../context/AuthContext'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthContext.Provider value={{ user: { name: 'Alice' } } as any}>
+    {children}
+  </AuthContext.Provider>
+)
+
+describe('useAuth hook', () => {
+  it('throws when used outside provider', () => {
+    expect(() => renderHook(() => useAuth())).toThrow('useAuth must be used')
+  })
+
+  it('returns context when inside provider', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    expect(result.current.user.name).toBe('Alice')
+  })
+})

--- a/src/__tests__/useTheme.test.tsx
+++ b/src/__tests__/useTheme.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTheme } from '../hooks/useTheme'
+
+describe('useTheme hook', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.className = ''
+    // stub matchMedia
+    ;(window as any).matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })
+  })
+
+  it('defaults to light when no saved preference', () => {
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('reads saved theme and toggles correctly', () => {
+    localStorage.setItem('theme', 'dark')
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('dark')
+    act(() => {
+      result.current.toggleTheme()
+    })
+    expect(result.current.theme).toBe('light')
+    expect(localStorage.getItem('theme')).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for all frontend pages to ensure they render
- test error state for PracticePage

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6856327d5a5883309597178f5bee6b18