### PR TITLE
Fix coverage tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sln
 *.sw?
 /project
+/coverage-frontend
+/coverage-backend

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,6 @@
+{
+  "extension": [".ts"],
+  "exclude": ["**/*.test.ts"],
+  "reporter": ["lcov", "text"],
+  "all": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/coverage-v8": "^1.6.1",
         "autoprefixer": "^10.4.20",
+        "c8": "^8.0.1",
         "chai": "^4.3.10",
         "eslint": "^9.9.0",
         "eslint-plugin-react": "^7.35.0",
@@ -3362,6 +3363,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4689,6 +4697,98 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c8": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
+      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^2.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "rimraf": "^3.0.2",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/c8/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/c8/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cac": {
@@ -13390,6 +13490,21 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,22 @@
     "tailwindcss": "^3.4.10",
     "tsx": "^4.20.3",
     "vite": "^5.4.1",
-    "vitest": "^1.4.0"
-    ,
+    "vitest": "^1.4.0",
     "c8": "^8.0.1"
+  },
+  "c8": {
+    "all": true,
+    "include": [
+      "server/**/*.ts"
+    ],
+    "exclude": [
+      "**/*.test.ts",
+      "**/test/**",
+      "server/**/*.tsx"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "heroku-postbuild": "vite build",
     "dev:server": "cross-env NODE_ENV=development nodemon --exec \"node --inspect=9300 --import ./loader-register.js --experimental-specifier-resolution=node\" server/server.ts",
     "prod:server": "cross-env NODE_ENV=production NODE_OPTIONS=\"--require ts-node/register/transpile-only\" node server/server.ts",
-    "test:back:coverage": "cross-env NODE_ENV=test nyc --report-dir=coverage-backend tsx ./node_modules/mocha/bin/mocha 'server/**/*.test.ts' --recursive --timeout 60000 --exit",
-    "test:front:coverage": "vitest run --coverage.dir=coverage-frontend",
+    "test:back:coverage": "cross-env NODE_ENV=test c8 -o coverage-backend tsx ./node_modules/mocha/bin/mocha 'server/**/*.test.ts' --recursive --timeout 60000 --exit",
+    "test:front:coverage": "vitest run --coverage --coverage.reportsDirectory=coverage-frontend",
     "test:back": "cross-env NODE_ENV=test tsx ./node_modules/mocha/bin/mocha 'server/**/*.test.ts' --recursive --timeout 60000 --exit",
     "test:front": "vitest run",
     "test": "npm run test:back && npm run test:front",
@@ -87,5 +87,7 @@
     "tsx": "^4.20.3",
     "vite": "^5.4.1",
     "vitest": "^1.4.0"
+    ,
+    "c8": "^8.0.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "allowImportingTsExtensions": true
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,19 +1,33 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import { configDefaults } from 'vitest/config'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { configDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   esbuild: {
-    loader: 'tsx',
+    loader: "tsx",
     include: /\.[jt]sx?$/,
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: './src/setupTests.ts',
-    include: ['src/**/*.test.{ts,tsx}'],
-    exclude: [...configDefaults.exclude, 'src/components/games/FlashcardMemoryGame/**', 'server/**'],
+    setupFiles: "./src/setupTests.ts",
+    include: ["src/**/*.test.{ts,tsx}"],
+    exclude: [
+      ...configDefaults.exclude,
+      "server/**",
+      "./server/**",
+      "**/server/**",
+    ],
+    coverage: {
+      exclude: [
+        "**/server/**",
+        "**/coverage-backend/**",
+        "postcss.config.js",
+        "tailwind.config.js",
+        "loader-register.js",
+      ],
+    },
   },
-})
+});


### PR DESCRIPTION
## Summary
- enable nyc configuration for TypeScript
- use c8 with tsx for backend coverage
- enable vitest coverage reporting directory
- add missing TS compiler option for `.ts` import paths

## Testing
- `npm run test:back:coverage`
- `npm run test:front:coverage`

------
https://chatgpt.com/codex/tasks/task_e_6856b62337fc8330b6ef1fb280cf01ca